### PR TITLE
provide enqueue_after method

### DIFF
--- a/.sqlx/query-3aabbeae862994ed4bf90f24d6c7c5992c022ab53683b6a43d86d4ffd294fc79.json
+++ b/.sqlx/query-3aabbeae862994ed4bf90f24d6c7c5992c022ab53683b6a43d86d4ffd294fc79.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select delay from underway.task\n            where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "delay",
+        "type_info": "Interval"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3aabbeae862994ed4bf90f24d6c7c5992c022ab53683b6a43d86d4ffd294fc79"
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -342,7 +342,7 @@ impl<T: Task> Worker<T> {
     }
 }
 
-fn pg_interval_to_span(
+pub(crate) fn pg_interval_to_span(
     PgInterval {
         months,
         days,


### PR DESCRIPTION
This allows tasks to be enqueued in a way that only makes them available after the specified delay. While tasks may already specify a delay, that configuration is static whereas this method allows for dynamic delays in accordance with runtime requirements.