### PR TITLE
provide graceful shutdown interface

### DIFF
--- a/.sqlx/query-45b1b27f9669db53892c4cfad7d09c0e325cfacbf1c37589300fb48e8d9eac49.json
+++ b/.sqlx/query-45b1b27f9669db53892c4cfad7d09c0e325cfacbf1c37589300fb48e8d9eac49.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select count(*)\n            from underway.task\n            where state = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "45b1b27f9669db53892c4cfad7d09c0e325cfacbf1c37589300fb48e8d9eac49"
+}

--- a/.sqlx/query-54d124a54b2bb28f85b3ee9882f1e103d8e690ea0cb5189411834b9d8b246fc4.json
+++ b/.sqlx/query-54d124a54b2bb28f85b3ee9882f1e103d8e690ea0cb5189411834b9d8b246fc4.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select pg_notify($1, $2)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_notify",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "54d124a54b2bb28f85b3ee9882f1e103d8e690ea0cb5189411834b9d8b246fc4"
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.40.0", features = [
 tracing = { version = "0.1.40", features = ["log"] }
 ulid = { version = "1.1.3", features = ["uuid"] }
 uuid = { version = "1.10.0", features = ["v4"] }
+num_cpus = "1.16.0"
 
 [dev-dependencies]
 futures = "0.3.30"


### PR DESCRIPTION
This introduces a mechanism for politely asking Underway to shutdown. To do so, a new function, `graceful_shutdown` is provided. Calling this function will send a notification to a Postgres channel. Workers listen on this channel and when a message is received will stop processing new tasks. If they're already processing a task, then they wait until that task is done or the task timeout has elapsed, whichever is first.

In order to cleanly stop the queue, this function should be used. If stopping in-progress tasks is safe for your use case, then this can be ignored and the queue can be stopped without any delay.

Closes #5