### PR TITLE
provide stateful jobs

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -607,8 +607,7 @@ where
     delay: Span,
     concurrency_key: Option<String>,
     priority: i32,
-    _marker: PhantomData<I>,
-    _state: PhantomData<S>,
+    _marker: PhantomData<(I, S)>,
 }
 
 impl<I, S> JobBuilder<I, S, ExecutorSet<I, S>>
@@ -676,7 +675,6 @@ where
             concurrency_key: None,
             priority: 0,
             _marker: PhantomData,
-            _state: PhantomData,
         }
     }
 
@@ -691,7 +689,6 @@ where
             concurrency_key: self.concurrency_key,
             priority: self.priority,
             _marker: PhantomData,
-            _state: PhantomData,
         }
     }
 
@@ -716,7 +713,6 @@ where
             concurrency_key: self.concurrency_key,
             priority: self.priority,
             _marker: PhantomData,
-            _state: PhantomData,
         }
     }
 }
@@ -757,7 +753,6 @@ where
             concurrency_key: self.concurrency_key,
             priority: self.priority,
             _marker: PhantomData,
-            _state: PhantomData,
         }
     }
 }
@@ -782,7 +777,6 @@ where
             concurrency_key: self.concurrency_key,
             priority: self.priority,
             _marker: PhantomData,
-            _state: PhantomData,
         }
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -611,7 +611,7 @@ where
     _state: PhantomData<S>,
 }
 
-impl<I, S, B> JobBuilder<I, S, B>
+impl<I, S> JobBuilder<I, S, ExecutorSet<I, S>>
 where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
     S: Clone + Send + Sync + 'static,

--- a/src/job.rs
+++ b/src/job.rs
@@ -593,7 +593,7 @@ mod builder_states {
     }
 }
 
-/// A builder of [`Job`].
+/// Builder for [`Job`].
 #[derive(Debug)]
 pub struct JobBuilder<I, S, B = Initial>
 where
@@ -615,44 +615,49 @@ where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
     S: Clone + Send + Sync + 'static,
 {
-    /// Sets the job's retry policy.
+    /// Set retry policy.
+    ///
+    /// See [`Task::retry_policy`].
     pub fn retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
         self.retry_policy = retry_policy;
         self
     }
 
-    /// Sets the job's timeout.
+    /// Set timeout.
+    ///
+    /// See [`Task::timeout`].
     pub fn timeout(mut self, timeout: Span) -> Self {
         self.timeout = timeout;
         self
     }
 
-    /// Sets the job's time-to-live (TTL).
+    /// Set time-to-live.
+    ///
+    /// See [`Task::ttl`].
     pub fn ttl(mut self, ttl: Span) -> Self {
         self.ttl = ttl;
         self
     }
 
-    /// Sets the job's delay.
+    /// Set delay.
     ///
-    /// The job will not be processed before this delay has elapsed.
+    /// See [`Task::delay`].
     pub fn delay(mut self, delay: Span) -> Self {
         self.delay = delay;
         self
     }
 
-    /// Sets the job's concurrency key.
+    /// Set concurrency key.
     ///
-    /// Concurrency keys ensure that only one job of the given key may be
-    /// processed at a time.
+    /// See [`Task::concurrency_key`].
     pub fn concurrency_key(mut self, concurrency_key: impl Into<String>) -> Self {
         self.concurrency_key = Some(concurrency_key.into());
         self
     }
 
-    /// Sets the job's priority.
+    /// Set priority.
     ///
-    /// Higher priorities are processed first.
+    /// See [`Task::priority`].
     pub fn priority(mut self, priority: i32) -> Self {
         self.priority = priority;
         self
@@ -678,7 +683,7 @@ where
         }
     }
 
-    /// Sets the job's state.,
+    /// Set state.
     pub fn state(self, state: S) -> JobBuilder<I, S, StateSet<S>> {
         JobBuilder {
             builder_state: StateSet { state },
@@ -692,7 +697,7 @@ where
         }
     }
 
-    /// Sets the job's execute method.
+    /// Set execute method.
     pub fn execute<F, Fut>(self, f: F) -> JobBuilder<I, S, ExecutorSet<I, ()>>
     where
         F: Fn(I) -> Fut + Send + Sync + 'static,
@@ -732,7 +737,7 @@ where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
     S: Clone + Send + Sync + 'static,
 {
-    /// Sets the job's execute method.
+    /// Set execute method.
     pub fn execute<F, Fut>(self, f: F) -> JobBuilder<I, S, ExecutorSet<I, S>>
     where
         F: Fn(I, S) -> Fut + Send + Sync + 'static,
@@ -762,7 +767,7 @@ where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
     S: Clone + Send + Sync + 'static,
 {
-    /// Set the queue name.
+    /// Set queue.
     pub fn queue(self, queue: Queue<Job<I, S>>) -> JobBuilder<I, S, QueueSet<I, S>> {
         JobBuilder {
             builder_state: QueueSet {
@@ -786,7 +791,7 @@ where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
     S: Clone + Send + Sync + 'static,
 {
-    /// Returns a configured [`Job`].
+    /// Returns a new [`Job`].
     pub fn build(self) -> Job<I, S> {
         let QueueSet {
             queue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@
 //!
 //!     // Build the job.
 //!     let job = Job::builder()
-//!         .queue(queue)
 //!         .execute(
 //!             |WelcomeEmail {
 //!                  user_id,
@@ -78,6 +77,7 @@
 //!                 Ok(())
 //!             },
 //!         )
+//!         .queue(queue)
 //!         .build();
 //!
 //!     // Enqueue a task.

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -61,11 +61,12 @@ impl<T: Task> Scheduler<T> {
     }
 }
 
-impl<I> From<Job<I>> for Scheduler<Job<I>>
+impl<I, S> From<Job<I, S>> for Scheduler<Job<I, S>>
 where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
+    S: Clone + Send + Sync + 'static,
 {
-    fn from(job: Job<I>) -> Self {
+    fn from(job: Job<I, S>) -> Self {
         Self {
             queue: job.queue.clone(),
             task: job,
@@ -73,11 +74,12 @@ where
     }
 }
 
-impl<I> From<&Job<I>> for Scheduler<Job<I>>
+impl<I, S> From<&Job<I, S>> for Scheduler<Job<I, S>>
 where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
+    S: Clone + Send + Sync + 'static,
 {
-    fn from(job: &Job<I>) -> Self {
+    fn from(job: &Job<I, S>) -> Self {
         Self {
             queue: job.queue.clone(),
             task: job.clone(),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -185,11 +185,12 @@ pub enum Error {
     Jiff(#[from] jiff::Error),
 }
 
-impl<I> From<Job<I>> for Worker<Job<I>>
+impl<I, S> From<Job<I, S>> for Worker<Job<I, S>>
 where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
+    S: Clone + Send + Sync + 'static,
 {
-    fn from(job: Job<I>) -> Self {
+    fn from(job: Job<I, S>) -> Self {
         Self {
             queue: job.queue.clone(),
             task: Arc::new(job),
@@ -199,11 +200,12 @@ where
     }
 }
 
-impl<I> From<&Job<I>> for Worker<Job<I>>
+impl<I, S> From<&Job<I, S>> for Worker<Job<I, S>>
 where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
+    S: Clone + Send + Sync + 'static,
 {
-    fn from(job: &Job<I>) -> Self {
+    fn from(job: &Job<I, S>) -> Self {
         Self {
             queue: job.queue.clone(),
             task: Arc::new(job.to_owned()),


### PR DESCRIPTION
This adds a facility for setting shared state on jobs via the `state` method on the job builder. When state is provided, the execute function must accept input and state, in that order, as arguments.

Shared state is useful in a number of ways, including when resources like database pools, should be accessible to your jobs.

Furthermore, patterns like `Arc<Mutex<T>>` enable shared mutable state, where necessary.