### PR TITLE
provide trait for converting to task results

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub use crate::{
     job::Job,
     queue::Queue,
     scheduler::{Scheduler, ZonedSchedule},
-    task::Task,
+    task::{Task, ToTaskResult},
     worker::Worker,
 };
 


### PR DESCRIPTION
This introduces a new trait, ToTaskResult, which makes it easier to convert results in execute futures to either retryable or fatal errors.

More specifically it provides two methods:

1. retryable
2. fatal

Which are implemented for Result where the error type implements Display.

When ToTaskResult is in scope, these methods will be available on results that meet its requirements and allow callers to ergonomically declare the desired conversion.