### PR TITLE
Step functions

### DIFF
--- a/.sqlx/query-05abadcb1abc6591d8b59bffd7cfe7a40ce6e5d935d34bb377e204acef918ab1.json
+++ b/.sqlx/query-05abadcb1abc6591d8b59bffd7cfe7a40ce6e5d935d34bb377e204acef918ab1.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "update underway.task set state = $2 where id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "05abadcb1abc6591d8b59bffd7cfe7a40ce6e5d935d34bb377e204acef918ab1"
+}

--- a/.sqlx/query-33d2dc54f81632a9b55321669436ecbeac7376c73197b52458b5a2af4f9dbf63.json
+++ b/.sqlx/query-33d2dc54f81632a9b55321669436ecbeac7376c73197b52458b5a2af4f9dbf63.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select schedule, timezone, input from underway.task_schedule where name = $1\n            ",
+  "query": "\n            select schedule, timezone, input from underway.task_schedule where name = $1\n            limit 1\n            ",
   "describe": {
     "columns": [
       {
@@ -30,5 +30,5 @@
       false
     ]
   },
-  "hash": "0339598605e18b851febb3b82f7fd6ea567963996799f3ad7826fced236cb656"
+  "hash": "33d2dc54f81632a9b55321669436ecbeac7376c73197b52458b5a2af4f9dbf63"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ tracing = { version = "0.1.40", features = ["log"] }
 ulid = { version = "1.1.3", features = ["uuid"] }
 uuid = { version = "1.10.0", features = ["v4", "serde"] }
 num_cpus = "1.16.0"
-futures = "0.3.30"
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ tokio = { version = "1.40.0", features = [
 ] } # TODO: "full" shouldn't be required
 tracing = { version = "0.1.40", features = ["log"] }
 ulid = { version = "1.1.3", features = ["uuid"] }
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid = { version = "1.10.0", features = ["v4", "serde"] }
 num_cpus = "1.16.0"
+futures = "0.3.30"
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </h1>
 
 <p align="center">
-    ⏳ <strong>Underway</strong> is a PostgreSQL-backed job queue for reliable background task processing.
+    ⏳ Durable step functions via Postgres.
 </p>
 
 <div align="center">
@@ -20,37 +20,51 @@
 
 ## 🎨 Overview
 
-Underway provides a robust and efficient way to execute asynchronous tasks using PostgreSQL as the backend for task storage and coordination. It is designed to be simple, scalable, and resilient, handling job processing in a way that ensures safe concurrency and reliable task execution. Whether you're processing tasks on a single server or across multiple workers, Underway makes it easy to manage background jobs with confidence.
+**Underway** is a framework for building robust, asynchronous background
+jobs in Rust, leveraging PostgreSQL as its queuing backend. It provides a
+streamlined interface for defining jobs as a series of "steps," where each
+step's output becomes the input for the next. This design enables the
+construction of complex, durable, and resilient workflows with ease.
 
 Key Features:
 
-- **PostgreSQL-Backed** Built on PostgreSQL for robust task storage and
-  coordination, ensuring consistency and safe concurrency across all
-  operations.
-- **Transactional Task Management** Supports enqueuing tasks within existing
-  database transactions, guaranteeing that tasks are only added if the
-  transaction commits successfully—perfect for operations like user
-  registration.
-- **Automatic Retries** Offers customizable retry strategies for failed
-  executions, ensuring tasks are reliably completed even after transient
-  failures.
-- **Cron-Like Scheduling** Supports scheduling recurring tasks with
-  cron-like expressions, enabling automated, time-based job execution.
-- **Scalable and Flexible** Scales from a single worker to multiple workers
-  with minimal configuration, allowing seamless background job processing.
+- **PostgreSQL-Backed** Leverages PostgreSQL with `FOR UPDATE SKIP LOCKED` for
+  reliable task storage and coordination, ensuring efficient, safe
+- **Atomic Task Management** Enqueue tasks within your transactions and use
+  the worker's transaction within your tasks for atomic database
+  queries--ensuring consisteny.
+- **Automatic Retries** Configurable retry strategies ensure tasks are
+  reliably completed, even after transient failures.
+- **Cron-Like Scheduling** Schedule recurring tasks with cron-like
+  expressions for automated, time-based job execution.
+- **Scalable and Flexible** Easily scales from a single worker to many,
+  enabling seamless background job processing with minimal setup.
 
 ## 🤸 Usage
+
+Underway is suitable for many different use cases, ranging from simple
+single-step jobs to more sophisticated multi-step jobs, where dependencies
+are built up between steps.
+
+## Welcome emails
+
+A common use case is deferring work that can be processed later. For
+instance, during user registration, we might want to send a welcome email to
+new users. Rather than handling this within the registration process (e.g.,
+form validation, database insertion), we can offload it to run "out-of-band"
+using Underway. By defining a job for sending the welcome email, Underway
+ensures it gets processed in the background, without slowing down the user
+registration flow.
 
 ```rust
 use std::env;
 
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
-use underway::{Job, Queue};
+use underway::{Job, To};
 
-const QUEUE_NAME: &str = "email";
-
-#[derive(Clone, Deserialize, Serialize)]
+// This is the input we'll provide to the job when we enqueue it.
+#[derive(Deserialize, Serialize)]
 struct WelcomeEmail {
     user_id: i32,
     email: String,
@@ -66,38 +80,157 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Run migrations.
     underway::MIGRATOR.run(&pool).await?;
 
-    // Create the task queue.
-    let queue = Queue::builder().name(QUEUE_NAME).pool(pool).build().await?;
-
     // Build the job.
     let job = Job::builder()
-        .execute(
-            |WelcomeEmail {
+        .step(
+            |_cx,
+             WelcomeEmail {
                  user_id,
                  email,
                  name,
              }| async move {
                 // Simulate sending an email.
                 println!("Sending welcome email to {name} <{email}> (user_id: {user_id})");
-                Ok(())
+                // Returning this indicates this is the final step.
+                To::done()
             },
         )
-        .queue(queue)
-        .build();
-
-    // Enqueue a job task.
-    let task_id = job
-        .enqueue(WelcomeEmail {
-            user_id: 42,
-            email: "ferris@example.com".to_string(),
-            name: "Ferris".to_string(),
-        })
+        .name("welcome-email")
+        .pool(pool)
+        .build()
         .await?;
 
-    println!("Enqueued task with ID: {task_id}");
+    // Here we enqueue a new job to be processed later.
+    job.enqueue(WelcomeEmail {
+        user_id: 42,
+        email: "ferris@example.com".to_string(),
+        name: "Ferris".to_string(),
+    })
+    .await?;
 
-    // Start the worker to process tasks.
-    job.run().await?;
+    // Start processing enqueued tasks.
+    job.start().await??;
+
+    Ok(())
+}
+```
+
+## Order receipts
+
+Another common use case is defining dependencies between discrete steps of a
+job. For instance, we might generate PDF receipts for orders and then email
+these to customers. With Underway, each step is handled separately, making
+it easy to create a job that first generates the PDF and, once
+completed, proceeds to send the email.
+
+This separation provides significant value: if the email sending service
+is temporarily unavailable, we can retry the email step without having to
+regenerate the PDF, avoiding unnecessary repeated work.
+
+```rust
+use std::env;
+
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use underway::{Job, To};
+
+#[derive(Deserialize, Serialize)]
+struct GenerateReceipt {
+    // An order we want to generate a receipt for.
+    order_id: i32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct EmailReceipt {
+    // An object store key to our receipt PDF.
+    receipt_key: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Set up the database connection pool.
+    let database_url = &env::var("DATABASE_URL").expect("DATABASE_URL should be set");
+    let pool = PgPool::connect(database_url).await?;
+
+    // Run migrations.
+    underway::MIGRATOR.run(&pool).await?;
+
+    // Build the job.
+    let job = Job::builder()
+        .step(|_cx, GenerateReceipt { order_id }| async move {
+            // Use the order ID to build a receipt PDF...
+            let receipt_key = format!("receipts_bucket/{order_id}-receipt.pdf");
+            // ...store the PDF in an object store.
+
+            // We proceed to the next step with the receipt_key as its input.
+            To::next(EmailReceipt { receipt_key })
+        })
+        .step(|_cx, EmailReceipt { receipt_key }| async move {
+            // Retrieve the PDF from the object store, and send the email.
+            println!("Emailing receipt for {receipt_key}");
+            To::done()
+        })
+        .name("order-receipt")
+        .pool(pool)
+        .build()
+        .await?;
+
+    // Enqueue the job for the given order.
+    job.enqueue(GenerateReceipt { order_id: 42 }).await?;
+
+    // Start processing enqueued jobs.
+    job.start().await??;
+
+    Ok(())
+}
+```
+
+With this setup, if the email service is down, the `EmailReceipt` step can
+be retried without redoing the PDF generation, saving time and resources by
+not repeating the expensive step of generating the PDF.
+
+## Daily reports
+
+Jobs may also be run on a schedule. This makes them useful for situations
+where we want to do things on a regular cadence, such as creating a daily
+business report.
+
+```rust
+use std::env;
+
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use underway::{Job, To};
+
+#[derive(Deserialize, Serialize)]
+struct DailyReport;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Set up the database connection pool.
+    let database_url = &env::var("DATABASE_URL").expect("DATABASE_URL should be set");
+    let pool = PgPool::connect(database_url).await?;
+
+    // Run migrations.
+    underway::MIGRATOR.run(&pool).await?;
+
+    // Build the job.
+    let job = Job::builder()
+        .step(|_cx, _| async move {
+            // Here we would generate and store the report.
+            To::done()
+        })
+        .name("daily-report")
+        .pool(pool)
+        .build()
+        .await?;
+
+    // Set a daily schedule with the given input.
+    let daily = "@daily[America/Los_Angeles]".parse()?;
+    job.schedule(daily, DailyReport).await?;
+
+    // Start processing enqueued jobs.
+    job.start().await??;
 
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -103,10 +103,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-## 🦺 Safety
-
-This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in 100% safe Rust.
-
 ## 🛟 Getting Help
 
 We've put together a number of [examples][examples] to help get you started. You're also welcome to [open a discussion](https://github.com/maxcountryman/underway/discussions/new?category=q-a) and ask additional questions you might have.

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
-use underway::{Job, StepState};
+use underway::{Job, To};
 
 const QUEUE_NAME: &str = "example-basic";
 
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              }| async move {
                 // Simulate sending an email.
                 println!("Sending welcome email to {name} <{email}> (user_id: {user_id})");
-                StepState::done()
+                To::done()
             },
         )
         .name(QUEUE_NAME)

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
-use underway::{Job, Queue};
+use underway::{Job, StepState};
 
 const QUEUE_NAME: &str = "example-basic";
 
@@ -22,24 +22,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Run migrations.
     underway::MIGRATOR.run(&pool).await?;
 
-    // Create the task queue.
-    let queue = Queue::builder().name(QUEUE_NAME).pool(pool).build().await?;
-
     // Build the job.
     let job = Job::builder()
-        .execute(
-            |WelcomeEmail {
+        .step(
+            |_ctx,
+             WelcomeEmail {
                  user_id,
                  email,
                  name,
              }| async move {
                 // Simulate sending an email.
                 println!("Sending welcome email to {name} <{email}> (user_id: {user_id})");
-                Ok(())
+                StepState::done()
             },
         )
-        .queue(queue)
-        .build();
+        .name(QUEUE_NAME)
+        .pool(pool)
+        .build()
+        .await?;
 
     // Enqueue a job task.
     let task_id = job

--- a/examples/graceful_shutdown/src/main.rs
+++ b/examples/graceful_shutdown/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use sqlx::PgPool;
 use tokio::signal;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use underway::{Job, StepState};
+use underway::{Job, To};
 
 const QUEUE_NAME: &str = "graceful-shutdown";
 
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Artificial delay to simulate a long-running job.
             tokio::time::sleep(sleep_duration).await;
 
-            StepState::done()
+            To::done()
         })
         .name(QUEUE_NAME)
         .pool(pool.clone())

--- a/examples/graceful_shutdown/src/main.rs
+++ b/examples/graceful_shutdown/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use sqlx::PgPool;
 use tokio::signal;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use underway::{Job, Queue};
+use underway::{Job, StepState};
 
 const QUEUE_NAME: &str = "graceful-shutdown";
 
@@ -50,16 +50,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Run migrations.
     underway::MIGRATOR.run(&pool).await?;
 
-    // Create the task queue.
-    let queue = Queue::builder()
-        .name(QUEUE_NAME)
-        .pool(pool.clone())
-        .build()
-        .await?;
-
     // Build the job.
     let job = Job::builder()
-        .execute(|_| async move {
+        .step(|_ctx, _input| async move {
             let sleep_duration = std::time::Duration::from_secs(5);
 
             tracing::info!(?sleep_duration, "Hello from a long-running task");
@@ -67,10 +60,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Artificial delay to simulate a long-running job.
             tokio::time::sleep(sleep_duration).await;
 
-            Ok(())
+            StepState::done()
         })
-        .queue(queue)
-        .build();
+        .name(QUEUE_NAME)
+        .pool(pool.clone())
+        .build()
+        .await?;
 
     let every_second = "* * * * * *[America/Los_Angeles]".parse()?;
     job.schedule(every_second, ()).await?;

--- a/examples/scheduled/src/main.rs
+++ b/examples/scheduled/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use sqlx::PgPool;
-use underway::{Job, StepState};
+use underway::{Job, To};
 
 const QUEUE_NAME: &str = "example-scheduled";
 
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let job = Job::builder()
         .step(|_ctx, _input| async move {
             println!("Hello, World!");
-            StepState::done()
+            To::done()
         })
         .name(QUEUE_NAME)
         .pool(pool)

--- a/examples/step/Cargo.toml
+++ b/examples/step/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-step"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+jiff = "0.1.13"
+serde = { version = "1.0.210", features = ["derive"] }
+sqlx = { version = "0.8.2", features = ["postgres", "runtime-tokio-rustls"] }
+tokio = { version = "1.34.0", features = ["full"] }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+underway = { path = "../../" }

--- a/examples/step/src/main.rs
+++ b/examples/step/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     job.enqueue(Start { n: 42 }).await?;
 
     // Run the job worker.
-    job.run().await?;
+    job.start().await??;
 
     Ok(())
 }

--- a/examples/step/src/main.rs
+++ b/examples/step/src/main.rs
@@ -4,9 +4,7 @@ use jiff::ToSpan;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use underway::{job::StepState, Job, Queue, Worker};
-
-const QUEUE_NAME: &str = "example-step";
+use underway::{job::StepState, Job};
 
 #[derive(Serialize, Deserialize)]
 struct Start {
@@ -40,13 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Run migrations.
     underway::MIGRATOR.run(&pool).await?;
 
-    // Create the task queue.
-    let queue = Queue::builder()
-        .name(QUEUE_NAME)
-        .pool(pool.clone())
-        .build()
-        .await?;
-
+    // Create our job.
     let job = Job::builder()
         .step(|Start { n }| async move {
             tracing::info!("Starting with {}", n);
@@ -58,19 +50,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tracing::info!("Squared: {}", n);
             let n = n % 10;
 
-            StepState::delay_for(Modulo { n }, 2.days())
+            tracing::info!("The next step is delayed for five seconds");
+            StepState::delay_for(Modulo { n }, 3.seconds())
         })
         .step(|Modulo { n }| async move {
             tracing::info!("Modulo 10 result: {}", n);
-
             StepState::done()
         })
-        .queue(queue.clone())
-        .build();
+        .name("example-step")
+        .pool(pool)
+        .build()
+        .await?;
 
-    job.enqueue(Start { n: 12 }).await?;
+    // Enqueue the first step.
+    job.enqueue(Start { n: 42 }).await?;
 
-    Worker::new(queue, job).run().await?;
+    // Run the job worker.
+    job.run().await?;
 
     Ok(())
 }

--- a/examples/step/src/main.rs
+++ b/examples/step/src/main.rs
@@ -1,0 +1,76 @@
+use std::env;
+
+use jiff::ToSpan;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use underway::{job::StepState, Job, Queue, Worker};
+
+const QUEUE_NAME: &str = "example-step";
+
+#[derive(Serialize, Deserialize)]
+struct Start {
+    n: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Power {
+    n: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Modulo {
+    n: usize,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize the tracing subscriber.
+    tracing_subscriber::registry()
+        .with(EnvFilter::new(
+            env::var("RUST_LOG").unwrap_or_else(|_| "debug,underway=info,sqlx=warn".into()),
+        ))
+        .with(tracing_subscriber::fmt::layer())
+        .try_init()?;
+
+    // Set up the database connection pool.
+    let database_url = &env::var("DATABASE_URL").expect("DATABASE_URL should be set");
+    let pool = PgPool::connect(database_url).await?;
+
+    // Run migrations.
+    underway::MIGRATOR.run(&pool).await?;
+
+    // Create the task queue.
+    let queue = Queue::builder()
+        .name(QUEUE_NAME)
+        .pool(pool.clone())
+        .build()
+        .await?;
+
+    let job = Job::builder()
+        .step(|Start { n }| async move {
+            tracing::info!("Starting with {}", n);
+            let n = n.pow(2);
+
+            StepState::to_next(Power { n })
+        })
+        .step(|Power { n }| async move {
+            tracing::info!("Squared: {}", n);
+            let n = n % 10;
+
+            StepState::delay_for(Modulo { n }, 2.days())
+        })
+        .step(|Modulo { n }| async move {
+            tracing::info!("Modulo 10 result: {}", n);
+
+            StepState::done()
+        })
+        .queue(queue.clone())
+        .build();
+
+    job.enqueue(Start { n: 12 }).await?;
+
+    Worker::new(queue, job).run().await?;
+
+    Ok(())
+}

--- a/examples/tracing/src/main.rs
+++ b/examples/tracing/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use underway::{Job, StepState};
+use underway::{Job, To};
 
 const QUEUE_NAME: &str = "example-tracing";
 
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              }| async move {
                 // Simulate sending an email.
                 tracing::info!("Sending welcome email to {name} <{email}> (user_id: {user_id})");
-                StepState::done()
+                To::done()
             },
         )
         .name(QUEUE_NAME)

--- a/src/job.rs
+++ b/src/job.rs
@@ -908,7 +908,7 @@ where
     #[instrument(
         skip_all,
         fields(
-            job.id = %input.job_id.as_hyphenated(), 
+            job.id = %input.job_id.as_hyphenated(),
             step = input.step_index + 1,
             steps = self.steps.len()
         ),

--- a/src/job.rs
+++ b/src/job.rs
@@ -1072,6 +1072,8 @@ where
     }
 }
 
+type StepResult = TaskResult<Option<(serde_json::Value, Span)>>;
+
 // A trait object wrapper for steps to allow heterogeneous step types in a
 // vector.
 trait StepExecutor<S>: Send + Sync {
@@ -1080,7 +1082,7 @@ trait StepExecutor<S>: Send + Sync {
         &self,
         cx: Context<S>,
         input: serde_json::Value,
-    ) -> Pin<Box<dyn Future<Output = TaskResult<Option<(serde_json::Value, Span)>>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = StepResult> + Send>>;
 }
 
 impl<I, O, S, F> StepExecutor<S> for StepFn<I, O, S, F>

--- a/src/job.rs
+++ b/src/job.rs
@@ -471,7 +471,7 @@ where
     I: Serialize + Sync + Send + 'static,
     S: Clone + Send + Sync + 'static,
 {
-    fn job_input(&self, input: I) -> Result<JobState> {
+    fn first_job_input(&self, input: I) -> Result<JobState> {
         let step_input = serde_json::to_value(input)?;
         let step_index = self.current_index.load(Ordering::SeqCst);
         let job_id = Ulid::new().into();
@@ -539,8 +539,7 @@ where
     where
         E: PgExecutor<'a>,
     {
-        let job_input = self.job_input(input)?;
-
+        let job_input = self.first_job_input(input)?;
         let id = self
             .queue
             .enqueue_after(executor, self, job_input, delay)
@@ -568,7 +567,7 @@ where
     where
         E: PgExecutor<'a>,
     {
-        let job_input = self.job_input(input)?;
+        let job_input = self.first_job_input(input)?;
         self.queue
             .schedule(executor, zoned_schedule, job_input)
             .await?;

--- a/src/job.rs
+++ b/src/job.rs
@@ -13,7 +13,7 @@
 //! A builder is provided allowing applications to define the configuration of
 //! their jobs. Minimally one step must be provided.
 //!
-//! ```rust
+//! ```rust,no_run
 //! # use sqlx::PgPool;
 //! # use underway::Queue;
 //! use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@
 //! # fn main() {
 //! # let rt = Runtime::new().unwrap();
 //! # rt.block_on(async {
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! # /*
 //! let pool = { /* A PgPool */ };
 //! # */
@@ -57,7 +57,8 @@
 //! Of course the point of creating a job is to use it to do something useful
 //! for us. In order to do so, we need to enqueue some input onto the job's
 //! queue. [`Job::enqueue`] does exactly this:
-//! ```rust
+//!
+//! ```rust,no_run
 //! # use sqlx::PgPool;
 //! use serde::{Deserialize, Serialize};
 //! use underway::{job::StepState, Job};
@@ -66,7 +67,7 @@
 //! # fn main() {
 //! # let rt = Runtime::new().unwrap();
 //! # rt.block_on(async {
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! # /*
 //! let pool = { /* A `PgPool`. */ };
 //! # */
@@ -108,7 +109,8 @@
 //! transaction be rolled back, then our job won't be enqueued. (An ID will
 //! still be returned by this method, so it's up to our application to recognize
 //! when a failure has occurred and ignore any such IDs.)
-//! ```rust
+//!
+//! ```rust,no_run
 //! # use sqlx::PgPool;
 //! # use underway::{Queue, job::StepState};
 //! # use serde::{Deserialize, Serialize};
@@ -117,7 +119,7 @@
 //! # fn main() {
 //! # let rt = Runtime::new().unwrap();
 //! # rt.block_on(async {
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! # let queue = Queue::builder()
 //! #    .name("example_queue")
 //! #    .pool(pool.clone())
@@ -161,7 +163,8 @@
 //! Once a job has been enqueued, a worker must be run in order to process it.
 //! Workers can be consructed from tasks, such as jobs. Jobs also provide a
 //! convenience method, [`Job::run`], for constructing and running a worker:
-//! ```rust
+//!
+//! ```rust,no_run
 //! # use sqlx::PgPool;
 //! # use underway::Queue;
 //! # use underway::{Job, job::StepState};
@@ -169,7 +172,7 @@
 //! # fn main() {
 //! # let rt = Runtime::new().unwrap();
 //! # rt.block_on(async {
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! # let queue = Queue::builder()
 //! #    .name("example_queue")
 //! #    .pool(pool)
@@ -197,7 +200,8 @@
 //! that daylight saving time (DST) arithmetic is performed correctly. DST can
 //! introduce subtle scheduling errors, so by explicitly running schedules in
 //! the provided time zone we ensure to account for it.
-//! ```rust
+//!
+//! ```rust,no_run
 //! # use sqlx::PgPool;
 //! # use underway::Queue;
 //! # use underway::Job;
@@ -207,14 +211,14 @@
 //! # fn main() {
 //! # let rt = Runtime::new().unwrap();
 //! # rt.block_on(async {
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! # let queue = Queue::builder()
 //! #    .name("example_queue")
 //! #    .pool(pool)
 //! #    .build()
 //! #    .await?;
 //! // Our task input type, used as config context here.
-//! #[derive(Clone, Serialize, Deserialize)]
+//! #[derive(Serialize, Deserialize)]
 //! struct JobConfig {
 //!     report_title: String,
 //! }
@@ -252,7 +256,8 @@
 //!
 //! Note that when a state is provided, the execute function must take first the
 //! input and then the state.
-//! ```rust
+//!
+//! ```rust,no_run
 //! # use sqlx::PgPool;
 //! # use underway::Queue;
 //! use serde::{Deserialize, Serialize};
@@ -262,7 +267,7 @@
 //! # fn main() {
 //! # let rt = Runtime::new().unwrap();
 //! # rt.block_on(async {
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! # let queue = Queue::builder()
 //! #    .name("example_queue")
 //! #    .pool(pool.clone())
@@ -310,7 +315,8 @@
 //! If the mutex is held across await points then an async-aware lock (such as
 //! [`tokio::sync::Mutex`]) is needed. That said, generally a synchronous lock
 //! is what you want and should be preferred.
-//! ```rust
+//!
+//! ```rust,no_run
 //! # use sqlx::PgPool;
 //! use std::sync::{Arc, Mutex};
 //!
@@ -321,7 +327,7 @@
 //! # fn main() {
 //! # let rt = Runtime::new().unwrap();
 //! # rt.block_on(async {
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! # /*
 //! let pool = { /* A `PgPool`. */ };
 //! # */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 //! use underway::{Job, To};
 //!
 //! #[derive(Deserialize, Serialize)]
-//! struct GenerateReport;
+//! struct DailyReport;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -212,7 +212,7 @@
 //!
 //!     // Set a daily schedule with the given input.
 //!     let daily = "@daily[America/Los_Angeles]".parse()?;
-//!     job.schedule(daily, GenerateReport).await?;
+//!     job.schedule(daily, DailyReport).await?;
 //!
 //!     // Start processing enqueued jobs.
 //!     job.start().await??;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,14 @@
 //! # Underway
 //!
-//! ⏳ A PostgreSQL-backed job queue for reliable background task processing.
+//! ⏳ Durable step functions via Postgres.
+//!
+//! # Overview
+//!
+//! **Underway** is a framework for building robust, asynchronous background
+//! jobs in Rust, leveraging PostgreSQL as its queuing backend. It provides a
+//! streamlined interface for defining jobs as a series of "steps," where each
+//! step's output becomes the input for the next. This design enables the
+//! construction of complex, durable, and resilient workflows with ease.
 //!
 //! Key Features:
 //!
@@ -9,7 +17,7 @@
 //!   concurrency.
 //! - **Atomic Task Management**: Enqueue tasks within your transactions and use
 //!   the worker's transaction within your tasks for atomic database
-//!   queries—ensuring consistent workflows.
+//!   queries--ensuring consisteny.
 //! - **Automatic Retries**: Configurable retry strategies ensure tasks are
 //!   reliably completed, even after transient failures.
 //! - **Cron-Like Scheduling**: Schedule recurring tasks with cron-like
@@ -17,22 +25,21 @@
 //! - **Scalable and Flexible**: Easily scales from a single worker to many,
 //!   enabling seamless background job processing with minimal setup.
 //!
-//! # Overview
+//! # Examples
 //!
-//! Underway provides a robust and efficient way to execute asynchronous tasks
-//! using PostgreSQL as the backend for task storage and coordination. It is
-//! designed to be simple, scalable, and resilient, handling job processing in
-//! a way that ensures safe concurrency and reliable task execution. Whether
-//! you're processing tasks on a single server or across multiple workers,
-//! Underway makes it easy to manage background jobs with confidence.
+//! Underway is suitable for many different use cases, ranging from simple
+//! single-step jobs to more sophisticated multi-step jobs, where dependencies
+//! are built up between steps.
 //!
-//! # Example
+//! ## Welcome emails
 //!
-//! Let's say we wanted to send welcome emails upon the successful registration
-//! of a new user. If we're building a web application, we want to defer work
-//! like this so we can return a response quickly back to the browser. We can
-//! use Underway to create a background job for sending emails without blocking
-//! the response:
+//! A common use case is deferring work that can be processed later. For
+//! instance, during user registration, we might want to send a welcome email to
+//! new users. Rather than handling this within the registration process (e.g.,
+//! form validation, database insertion), we can offload it to run "out-of-band"
+//! using Underway. By defining a job for sending the welcome email, Underway
+//! ensures it gets processed in the background, without slowing down the user
+//! registration flow.
 //!
 //! ```rust,no_run
 //! use std::env;
@@ -41,6 +48,7 @@
 //! use sqlx::PgPool;
 //! use underway::{Job, To};
 //!
+//! // This is the input we'll provide to the job when we enqueue it.
 //! #[derive(Deserialize, Serialize)]
 //! struct WelcomeEmail {
 //!     user_id: i32,
@@ -60,7 +68,7 @@
 //!     // Build the job.
 //!     let job = Job::builder()
 //!         .step(
-//!             |_ctx,
+//!             |_cx,
 //!              WelcomeEmail {
 //!                  user_id,
 //!                  email,
@@ -68,6 +76,7 @@
 //!              }| async move {
 //!                 // Simulate sending an email.
 //!                 println!("Sending welcome email to {name} <{email}> (user_id: {user_id})");
+//!                 // Returning this indicates this is the final step.
 //!                 To::done()
 //!             },
 //!         )
@@ -76,16 +85,13 @@
 //!         .build()
 //!         .await?;
 //!
-//!     // Enqueue a task.
-//!     let task_id = job
-//!         .enqueue(WelcomeEmail {
-//!             user_id: 42,
-//!             email: "ferris@example.com".to_string(),
-//!             name: "Ferris".to_string(),
-//!         })
-//!         .await?;
-//!
-//!     println!("Enqueued task with ID: {}", task_id);
+//!     // Here we enqueue a new job to be processed later.
+//!     job.enqueue(WelcomeEmail {
+//!         user_id: 42,
+//!         email: "ferris@example.com".to_string(),
+//!         name: "Ferris".to_string(),
+//!     })
+//!     .await?;
 //!
 //!     // Start processing enqueued tasks.
 //!     job.start().await??;
@@ -94,11 +100,17 @@
 //! }
 //! ```
 //!
-//! Another common use case is doing something after some expensive bit of work
-//! has been done with that output. For instance, we might generate PDF receipts
-//!  of orders and then send these via email to our customers. Because jobs are
-//! a series of sequential steps, we can write a job that handles PDF generation
-//! and then sends a receipt email.
+//! ## Order receipts
+//!
+//! Another common use case is defining dependencies between discrete steps of a
+//! job. For instance, we might generate PDF receipts for orders and then email
+//! these to customers. With Underway, each step is handled separately, making
+//! it easy to create a job that first generates the PDF and, once
+//! completed, proceeds to send the email.
+//!
+//! This separation provides significant value: if the email sending service
+//! is temporarily unavailable, we can retry the email step without having to
+//! regenerate the PDF, avoiding unnecessary repeated work.
 //!
 //! ```rust,no_run
 //! use std::env;
@@ -109,13 +121,13 @@
 //!
 //! #[derive(Deserialize, Serialize)]
 //! struct GenerateReceipt {
-//!     // The order we want to generate a receipt for.
+//!     // An order we want to generate a receipt for.
 //!     order_id: i32,
 //! }
 //!
 //! #[derive(Deserialize, Serialize)]
 //! struct EmailReceipt {
-//!     // The object store key to our receipt PDF.
+//!     // An object store key to our receipt PDF.
 //!     receipt_key: String,
 //! }
 //!
@@ -130,37 +142,84 @@
 //!
 //!     // Build the job.
 //!     let job = Job::builder()
-//!         .step(|_ctx, GenerateReceipt { order_id }| async move {
+//!         .step(|_cx, GenerateReceipt { order_id }| async move {
 //!             // Use the order ID to build a receipt PDF...
-//!             // ...store the PDF in an object store.
 //!             let receipt_key = format!("receipts_bucket/{order_id}-receipt.pdf");
+//!             // ...store the PDF in an object store.
+//!
+//!             // We proceed to the next step with the receipt_key as its input.
 //!             To::next(EmailReceipt { receipt_key })
 //!         })
-//!         .step(|_ctx, EmailReceipt { receipt_key }| async move {
+//!         .step(|_cx, EmailReceipt { receipt_key }| async move {
 //!             // Retrieve the PDF from the object store, and send the email.
 //!             println!("Emailing receipt for {receipt_key}");
 //!             To::done()
 //!         })
-//!         .name("email-receipt")
+//!         .name("order-receipt")
 //!         .pool(pool)
 //!         .build()
 //!         .await?;
 //!
-//!     // Enqueue a task.
-//!     let task_id = job.enqueue(GenerateReceipt { order_id: 42 }).await?;
+//!     // Enqueue the job for the given order.
+//!     job.enqueue(GenerateReceipt { order_id: 42 }).await?;
 //!
-//!     println!("Enqueued task with ID: {}", task_id);
-//!
-//!     // Start processing enqueued tasks.
+//!     // Start processing enqueued jobs.
 //!     job.start().await??;
 //!
 //!     Ok(())
 //! }
 //! ```
 //!
-//! If the email sending service is down, our email receipt step might fail. But
-//! because the receipt PDF has already been built, when we retry we'll only
-//! retry the email receipt step, without redoing the PDF generation step.
+//! With this setup, if the email service is down, the `EmailReceipt` step can
+//! be retried without redoing the PDF generation, saving time and resources by
+//! not repeating the expensive step of generating the PDF.
+//!
+//! ## Daily reports
+//!
+//! Jobs may also be run on a schedule. This makes them useful for situations
+//! where we want to do things on a regular cadence, such as creating a daily
+//! business report.
+//!
+//! ```rust,no_run
+//! use std::env;
+//!
+//! use serde::{Deserialize, Serialize};
+//! use sqlx::PgPool;
+//! use underway::{Job, To};
+//!
+//! #[derive(Deserialize, Serialize)]
+//! struct GenerateReport;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Set up the database connection pool.
+//!     let database_url = &env::var("DATABASE_URL").expect("DATABASE_URL should be set");
+//!     let pool = PgPool::connect(database_url).await?;
+//!
+//!     // Run migrations.
+//!     underway::MIGRATOR.run(&pool).await?;
+//!
+//!     // Build the job.
+//!     let job = Job::builder()
+//!         .step(|_cx, _| async move {
+//!             // Here we would generate and store the report.
+//!             To::done()
+//!         })
+//!         .name("daily-report")
+//!         .pool(pool)
+//!         .build()
+//!         .await?;
+//!
+//!     // Set a daily schedule with the given input.
+//!     let daily = "@daily[America/Los_Angeles]".parse()?;
+//!     job.schedule(daily, GenerateReport).await?;
+//!
+//!     // Start processing enqueued jobs.
+//!     job.start().await??;
+//!
+//!     Ok(())
+//! }
+//! ```
 //!
 //! # Concepts
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! use serde::{Deserialize, Serialize};
 //! use sqlx::PgPool;
-//! use underway::{Job, Queue};
+//! use underway::{Job, Queue, StepState};
 //!
 //! const QUEUE_NAME: &str = "email";
 //!
@@ -66,15 +66,16 @@
 //!
 //!     // Build the job.
 //!     let job = Job::builder()
-//!         .execute(
-//!             |WelcomeEmail {
+//!         .step(
+//!             |_ctx,
+//!              WelcomeEmail {
 //!                  user_id,
 //!                  email,
 //!                  name,
 //!              }| async move {
 //!                 // Simulate sending an email.
 //!                 println!("Sending welcome email to {name} <{email}> (user_id: {user_id})");
-//!                 Ok(())
+//!                 StepState::done()
 //!             },
 //!         )
 //!         .queue(queue)
@@ -147,7 +148,7 @@
 use sqlx::migrate::Migrator;
 
 pub use crate::{
-    job::Job,
+    job::{Job, StepState},
     queue::Queue,
     scheduler::{Scheduler, ZonedSchedule},
     task::{Task, ToTaskResult},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,6 @@
 //! See [`worker`] for more details about workers.
 
 #![warn(clippy::all, nonstandard_style, future_incompatible, missing_docs)]
-#![forbid(unsafe_code)]
 
 use sqlx::migrate::Migrator;
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -622,6 +622,7 @@ impl<T: Task> Queue<T> {
         Ok(())
     }
 
+    #[allow(dead_code)] // TODO: Revisit cancellation re jobs.
     pub(crate) async fn mark_task_cancelled<'a, E>(&self, executor: E, task_id: TaskId) -> Result
     where
         E: PgExecutor<'a>,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -29,7 +29,8 @@
 //! # struct MyTask;
 //! # impl Task for MyTask {
 //! #    type Input = ();
-//! #    async fn execute(&self, input: Self::Input) -> TaskResult {
+//! #    type Output = ();
+//! #    async fn execute(&self, input: Self::Input) -> TaskResult<Self::Output> {
 //! #        Ok(())
 //! #    }
 //! # }
@@ -78,7 +79,8 @@
 //! # struct MyTask;
 //! # impl Task for MyTask {
 //! #    type Input = ();
-//! #    async fn execute(&self, input: Self::Input) -> TaskResult {
+//! #    type Output = ();
+//! #    async fn execute(&self, input: Self::Input) -> TaskResult<Self::Output> {
 //! #        Ok(())
 //! #    }
 //! # }
@@ -137,7 +139,8 @@
 //! # struct MyTask;
 //! # impl Task for MyTask {
 //! #    type Input = ();
-//! #    async fn execute(&self, input: Self::Input) -> TaskResult {
+//! #    type Output = ();
+//! #    async fn execute(&self, input: Self::Input) -> TaskResult<Self::Output> {
 //! #        Ok(())
 //! #    }
 //! # }
@@ -194,7 +197,8 @@
 //! # struct MyTask;
 //! # impl Task for MyTask {
 //! #    type Input = ();
-//! #    async fn execute(&self, input: Self::Input) -> TaskResult {
+//! #    type Output = ();
+//! #    async fn execute(&self, input: Self::Input) -> TaskResult<Self::Output> {
 //! #        Ok(())
 //! #    }
 //! # }
@@ -978,8 +982,9 @@ mod tests {
 
     impl Task for TestTask {
         type Input = serde_json::Value;
+        type Output = ();
 
-        async fn execute(&self, _: Self::Input) -> TaskResult {
+        async fn execute(&self, _: Self::Input) -> TaskResult<Self::Output> {
             Ok(())
         }
     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -979,6 +979,8 @@ where
 mod tests {
     use std::collections::HashSet;
 
+    use sqlx::Transaction;
+
     use super::*;
     use crate::{task::Result as TaskResult, worker::pg_interval_to_span};
 
@@ -988,7 +990,11 @@ mod tests {
         type Input = serde_json::Value;
         type Output = ();
 
-        async fn execute(&self, _: Self::Input) -> TaskResult<Self::Output> {
+        async fn execute(
+            &self,
+            _: Transaction<'_, Postgres>,
+            _: Self::Input,
+        ) -> TaskResult<Self::Output> {
             Ok(())
         }
     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -19,18 +19,19 @@
 //!
 //! To enable dead-letter queues, simply provide its name:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # use tokio::runtime::Runtime;
 //! # use underway::Task;
 //! # use underway::task::Result as TaskResult;
 //! # use sqlx::PgPool;
+//! # use sqlx::{Transaction, Postgres};
 //! use underway::Queue;
 //!
 //! # struct MyTask;
 //! # impl Task for MyTask {
 //! #    type Input = ();
 //! #    type Output = ();
-//! #    async fn execute(&self, input: Self::Input) -> TaskResult<Self::Output> {
+//! #    async fn execute(&self, _tx: Transaction<'_, Postgres>, input: Self::Input) -> TaskResult<Self::Output> {
 //! #        Ok(())
 //! #    }
 //! # }
@@ -40,7 +41,7 @@
 //! # /*
 //! let pool = { /* A `PgPool`. */ };
 //! # */
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! let queue = Queue::builder()
 //!     .name("example_queue")
 //!     // Enable the dead-letter queue.
@@ -69,18 +70,18 @@
 //! With that said, a queue may be interfaced with directly and operated
 //! manually if desired:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # use tokio::runtime::Runtime;
 //! # use underway::Task;
 //! # use underway::task::Result as TaskResult;
-//! # use sqlx::PgPool;
+//! # use sqlx::{Transaction, Postgres, PgPool};
 //! use underway::Queue;
 //!
 //! # struct MyTask;
 //! # impl Task for MyTask {
 //! #    type Input = ();
 //! #    type Output = ();
-//! #    async fn execute(&self, input: Self::Input) -> TaskResult<Self::Output> {
+//! #    async fn execute(&self, _tx: Transaction<'_, Postgres>, input: Self::Input) -> TaskResult<Self::Output> {
 //! #        Ok(())
 //! #    }
 //! # }
@@ -90,7 +91,7 @@
 //! # /*
 //! let pool = { /* A `PgPool`. */ };
 //! # */
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! let queue = Queue::builder()
 //!     .name("example_queue")
 //!     .pool(pool.clone())
@@ -129,18 +130,18 @@
 //! used to run the schedule via the [`Scheduler::run`](crate::Scheduler::run)
 //! method:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # use tokio::runtime::Runtime;
 //! # use underway::Task;
 //! # use underway::task::Result as TaskResult;
-//! # use sqlx::PgPool;
+//! # use sqlx::{Transaction, Postgres, PgPool};
 //! use underway::{Queue, Scheduler};
 //!
 //! # struct MyTask;
 //! # impl Task for MyTask {
 //! #    type Input = ();
 //! #    type Output = ();
-//! #    async fn execute(&self, input: Self::Input) -> TaskResult<Self::Output> {
+//! #    async fn execute(&self, _tx: Transaction<'_, Postgres>, input: Self::Input) -> TaskResult<Self::Output> {
 //! #        Ok(())
 //! #    }
 //! # }
@@ -150,7 +151,7 @@
 //! # /*
 //! let pool = { /* A `PgPool`. */ };
 //! # */
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! let queue = Queue::builder()
 //!     .name("example_queue")
 //!     .pool(pool.clone())
@@ -187,18 +188,18 @@
 //! **Note**: Tasks will not be deleted from the queue if this routine is not
 //! running!
 //!
-//! ```rust
+//! ```rust,no_run
 //! # use tokio::runtime::Runtime;
 //! # use underway::Task;
 //! # use underway::task::Result as TaskResult;
-//! # use sqlx::PgPool;
+//! # use sqlx::{Postgres, PgPool, Transaction};
 //! use underway::queue;
 //!
 //! # struct MyTask;
 //! # impl Task for MyTask {
 //! #    type Input = ();
 //! #    type Output = ();
-//! #    async fn execute(&self, input: Self::Input) -> TaskResult<Self::Output> {
+//! #    async fn execute(&self, _tx: Transaction<'_, Postgres>, input: Self::Input) -> TaskResult<Self::Output> {
 //! #        Ok(())
 //! #    }
 //! # }
@@ -208,7 +209,7 @@
 //! # /*
 //! let pool = { /* A `PgPool`. */ };
 //! # */
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //!
 //! // Ensure we remove tasks that have an expired TTL.
 //! queue::run_deletion(&pool).await?;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -90,12 +90,13 @@ impl<T: Task> Scheduler<T> {
     }
 }
 
-impl<I, S> From<Job<I, S>> for Scheduler<Job<I, S>>
+impl<I, O, S> From<Job<I, O, S>> for Scheduler<Job<I, O, S>>
 where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
+    O: Clone + Serialize + Send + 'static,
     S: Clone + Send + Sync + 'static,
 {
-    fn from(job: Job<I, S>) -> Self {
+    fn from(job: Job<I, O, S>) -> Self {
         Self {
             queue: job.queue.clone(),
             queue_lock: queue_scheduler_lock(&job.queue.name),
@@ -104,12 +105,13 @@ where
     }
 }
 
-impl<I, S> From<&Job<I, S>> for Scheduler<Job<I, S>>
+impl<I, O, S> From<&Job<I, O, S>> for Scheduler<Job<I, O, S>>
 where
     I: Clone + DeserializeOwned + Serialize + Send + 'static,
+    O: Clone + Serialize + Send + 'static,
     S: Clone + Send + Sync + 'static,
 {
-    fn from(job: &Job<I, S>) -> Self {
+    fn from(job: &Job<I, O, S>) -> Self {
         Self {
             queue: job.queue.clone(),
             queue_lock: queue_scheduler_lock(&job.queue.name),

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -42,12 +42,12 @@ pub struct Scheduler<T: Task> {
 
 impl<T: Task> Scheduler<T> {
     /// Creates a new scheduler.
-    pub fn new(queue: Queue<T>, task: Arc<T>) -> Self {
+    pub fn new(queue: Queue<T>, task: T) -> Self {
         let queue_lock = queue_scheduler_lock(&queue.name);
         Self {
             queue,
             queue_lock,
-            task,
+            task: Arc::new(task),
         }
     }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -90,35 +90,35 @@ impl<T: Task> Scheduler<T> {
     }
 }
 
-impl<I, O, S> From<Job<I, O, S>> for Scheduler<Job<I, O, S>>
-where
-    I: Clone + DeserializeOwned + Serialize + Send + 'static,
-    O: Clone + Serialize + Send + 'static,
-    S: Clone + Send + Sync + 'static,
-{
-    fn from(job: Job<I, O, S>) -> Self {
-        Self {
-            queue: job.queue.clone(),
-            queue_lock: queue_scheduler_lock(&job.queue.name),
-            task: job,
-        }
-    }
-}
-
-impl<I, O, S> From<&Job<I, O, S>> for Scheduler<Job<I, O, S>>
-where
-    I: Clone + DeserializeOwned + Serialize + Send + 'static,
-    O: Clone + Serialize + Send + 'static,
-    S: Clone + Send + Sync + 'static,
-{
-    fn from(job: &Job<I, O, S>) -> Self {
-        Self {
-            queue: job.queue.clone(),
-            queue_lock: queue_scheduler_lock(&job.queue.name),
-            task: job.clone(),
-        }
-    }
-}
+//impl<I, O, S> From<Job<I, O, S>> for Scheduler<Job<I, O, S>>
+//where
+//    I: Clone + DeserializeOwned + Serialize + Send + 'static,
+//    O: Clone + Serialize + Send + 'static,
+//    S: Clone + Send + Sync + 'static,
+//{
+//    fn from(job: Job<I, O, S>) -> Self {
+//        Self {
+//            queue: job.queue.clone(),
+//            queue_lock: queue_scheduler_lock(&job.queue.name),
+//            task: job,
+//        }
+//    }
+//}
+//
+//impl<I, O, S> From<&Job<I, O, S>> for Scheduler<Job<I, O, S>>
+//where
+//    I: Clone + DeserializeOwned + Serialize + Send + 'static,
+//    O: Clone + Serialize + Send + 'static,
+//    S: Clone + Send + Sync + 'static,
+//{
+//    fn from(job: &Job<I, O, S>) -> Self {
+//        Self {
+//            queue: job.queue.clone(),
+//            queue_lock: queue_scheduler_lock(&job.queue.name),
+//            task: job.clone(),
+//        }
+//    }
+//}
 
 fn queue_scheduler_lock(queue_name: &str) -> PgAdvisoryLock {
     PgAdvisoryLock::new(format!("{queue_name}-scheduler"))

--- a/src/task.rs
+++ b/src/task.rs
@@ -131,13 +131,13 @@ pub enum Error {
 ///
 ///```rust
 /// use tokio::net;
-/// use underway::{Job, StepState, ToTaskResult};
+/// use underway::{Job, To, ToTaskResult};
 ///
 /// Job::<(), ()>::builder().step(|_, _| async {
 ///     // If we can't resolve DNS the issue may be transient and recoverable.
 ///     net::lookup_host("example.com:80").await.retryable()?;
 ///
-///     StepState::done()
+///     To::done()
 /// });
 /// ```
 ///
@@ -146,13 +146,13 @@ pub enum Error {
 /// ```rust
 /// use std::env;
 ///
-/// use underway::{Job, StepState, ToTaskResult};
+/// use underway::{Job, To, ToTaskResult};
 ///
 /// Job::<(), ()>::builder().step(|_, _| async {
 ///     // If the API_KEY environment variable isn't set we can't recover.
 ///     let api_key = env::var("API_KEY").fatal()?;
 ///
-///     StepState::done()
+///     To::done()
 /// });
 /// ```
 pub trait ToTaskResult<T> {

--- a/src/task.rs
+++ b/src/task.rs
@@ -508,7 +508,7 @@ pub enum State {
 #[cfg(test)]
 mod tests {
     use serde::{Deserialize, Serialize};
-    use sqlx::{Acquire, PgPool};
+    use sqlx::PgPool;
 
     use super::*;
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -71,7 +71,7 @@ use std::{future::Future, result::Result as StdResult};
 
 use jiff::{Span, ToSpan};
 use serde::{de::DeserializeOwned, Serialize};
-use sqlx::{postgres::types::PgInterval, PgConnection};
+use sqlx::{postgres::types::PgInterval, Postgres, Transaction};
 use uuid::Uuid;
 
 pub(crate) use self::retry_policy::RetryCount;
@@ -210,7 +210,7 @@ pub trait Task: Send + 'static {
     ///     /// Simulate sending a welcome email by printing a message to the console.
     ///     async fn execute(
     ///         &self,
-    ///         _conn: &mut PgConnection,
+    ///         conn: &mut PgConnection,
     ///         input: Self::Input,
     ///     ) -> TaskResult<Self::Output> {
     ///         println!(
@@ -224,9 +224,9 @@ pub trait Task: Send + 'static {
     ///     }
     /// }
     /// ```
-    fn execute(
+    fn execute<'a>(
         &self,
-        conn: &mut PgConnection,
+        conn: Transaction<'a, Postgres>,
         input: Self::Input,
     ) -> impl Future<Output = Result<Self::Output>> + Send;
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -18,7 +18,7 @@
 //! worker. However, workers can be manually constructed and only require a
 //! queue and task:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # use tokio::runtime::Runtime;
 //! # use underway::Task;
 //! # use underway::task::Result as TaskResult;
@@ -40,7 +40,7 @@
 //! # /*
 //! let pool = { /* A `PgPool`. */ };
 //! # */
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! let queue = Queue::builder()
 //!     .name("example_queue")
 //!     .pool(pool.clone())
@@ -69,25 +69,24 @@
 //! manner. Also note that workers do not need to be run in-process, and can be
 //! run from a separate binary altogether.
 //!
-//! ```rust
+//! ```rust,no_run
 //! # use tokio::runtime::Runtime;
 //! # use underway::Task;
 //! # use underway::task::Result as TaskResult;
-//! # use sqlx::PgPool;
+//! # use sqlx::{Transaction, Postgres, PgPool};
 //! # use underway::{Queue, Worker};
-//! # #[derive(Clone)]
 //! # struct MyTask;
 //! # impl Task for MyTask {
 //! #    type Input = ();
 //! #    type Output = ();
-//! #    async fn execute(&self, input: Self::Input) -> TaskResult<Self::Output> {
+//! #    async fn execute(&self, _tx: Transaction<'_, Postgres>, input: Self::Input) -> TaskResult<Self::Output> {
 //! #        Ok(())
 //! #    }
 //! # }
 //! # fn main() {
 //! # let rt = Runtime::new().unwrap();
 //! # rt.block_on(async {
-//! # let pool = PgPool::connect("postgres://user:password@localhost/database").await?;
+//! # let pool = PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
 //! # let queue = Queue::builder()
 //! #    .name("example_queue")
 //! #    .pool(pool.clone())

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -187,37 +187,37 @@ pub enum Error {
     Jiff(#[from] jiff::Error),
 }
 
-impl<I, O, S> From<Job<I, O, S>> for Worker<Job<I, O, S>>
-where
-    I: Clone + DeserializeOwned + Serialize + Send + 'static,
-    O: Clone + Serialize + Send + 'static,
-    S: Clone + Send + Sync + 'static,
-{
-    fn from(job: Job<I, O, S>) -> Self {
-        Self {
-            queue: job.queue.clone(),
-            task: Arc::new(job),
-            concurrency_limit: num_cpus::get(),
-            queue_shutdown: Arc::new(false.into()),
-        }
-    }
-}
-
-impl<I, O, S> From<&Job<I, O, S>> for Worker<Job<I, O, S>>
-where
-    I: Clone + DeserializeOwned + Serialize + Send + 'static,
-    O: Clone + Serialize + Send + 'static,
-    S: Clone + Send + Sync + 'static,
-{
-    fn from(job: &Job<I, O, S>) -> Self {
-        Self {
-            queue: job.queue.clone(),
-            task: Arc::new(job.to_owned()),
-            concurrency_limit: num_cpus::get(),
-            queue_shutdown: Arc::new(false.into()),
-        }
-    }
-}
+//impl<I, O, S> From<Job<I, O, S>> for Worker<Job<I, O, S>>
+//where
+//    I: Clone + DeserializeOwned + Serialize + Send + 'static,
+//    O: Clone + Serialize + Send + 'static,
+//    S: Clone + Send + Sync + 'static,
+//{
+//    fn from(job: Job<I, O, S>) -> Self {
+//        Self {
+//            queue: job.queue.clone(),
+//            task: Arc::new(job),
+//            concurrency_limit: num_cpus::get(),
+//            queue_shutdown: Arc::new(false.into()),
+//        }
+//    }
+//}
+//
+//impl<I, O, S> From<&Job<I, O, S>> for Worker<Job<I, O, S>>
+//where
+//    I: Clone + DeserializeOwned + Serialize + Send + 'static,
+//    O: Clone + Serialize + Send + 'static,
+//    S: Clone + Send + Sync + 'static,
+//{
+//    fn from(job: &Job<I, O, S>) -> Self {
+//        Self {
+//            queue: job.queue.clone(),
+//            task: Arc::new(job.to_owned()),
+//            concurrency_limit: num_cpus::get(),
+//            queue_shutdown: Arc::new(false.into()),
+//        }
+//    }
+//}
 
 impl<T: Task + Sync> Worker<T> {
     /// Creates a new worker with the given queue and task.
@@ -358,7 +358,7 @@ impl<T: Task + Sync> Worker<T> {
                 .expect("Task timeout should be compatible with std::time");
 
             tokio::select! {
-                result = self.task.execute(input) => {
+                result = self.task.execute(&mut tx, input) => {
                     match result {
                         Ok(_) => {
                             self.queue.mark_task_succeeded(&mut *tx, task_id).await?;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -306,7 +306,7 @@ impl<T: Task + Sync> Worker<T> {
     /// left, then the task will be re-queued in a
     /// [`Pending`](crate::task::State::Pending) state.
     #[instrument(
-        skip(self), 
+        skip(self),
         fields(
             queue.name = self.queue.name,
             task.id = tracing::field::Empty,


### PR DESCRIPTION
This introduces step functions.

Step functions are a series of linked tasks where each task takes input from the output of previous one. Said another way, step functions are a chain of dependent tasks, each depending on its immediate ancestor. 

This design makes it possible to define a series of discrete tasks that can perform work which is required for further work as the series progresses. What this means is that when tasks fail and are retried, prior work is not repeated.

With this patch jobs are now composed of one or more step functions.

Enabling this interface also necessitates updating tasks to:

1. Provide an output as an associated type and,
2. Take a transaction as input to their execute method.

It's worth noting that various breaking changes are contained throughout and this is a significant change to the job API especially. 

Note that on series `0.0.x` we are **NOT** adhering to proper semver. Please upgrade with caution until the `0.1.x` series.
