### PR TITLE
use cancellation token for shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { version = "0.1.40", features = ["log"] }
 ulid = { version = "1.1.3", features = ["uuid"] }
 uuid = { version = "1.10.0", features = ["v4", "serde"] }
 num_cpus = "1.16.0"
+tokio-util = "0.7.12"
 
 [dev-dependencies]
 futures = "0.3.30"


### PR DESCRIPTION
This refactors worker shutdown to use a cancellation token to signal shutdown. By doing so, we can avoid managing an atomic bool. It also makes it possible to provide addtional methods, such as a `shutdown` method, on the worker itself to signal shutdown.