### PR TITLE
refactor scheduler

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Enqueue a job task.
     let task_id = job
-        .enqueue(WelcomeEmail {
+        .enqueue(&WelcomeEmail {
             user_id: 42,
             email: "ferris@example.com".to_string(),
             name: "Ferris".to_string(),

--- a/examples/multitask/src/main.rs
+++ b/examples/multitask/src/main.rs
@@ -30,7 +30,7 @@ impl WelcomeEmailTask {
         // This ensures our task-specific configuration is applied.
         let welcome_email_task = self.into();
         queue
-            .enqueue(pool, &welcome_email_task, TaskInput::WelcomeEmail(input))
+            .enqueue(pool, &welcome_email_task, &TaskInput::WelcomeEmail(input))
             .await
     }
 }
@@ -63,7 +63,7 @@ impl OrderTask {
         // This ensures our task-specific configuration is applied.
         let order_task = self.into();
         queue
-            .enqueue(pool, &order_task, TaskInput::Order(input))
+            .enqueue(pool, &order_task, &TaskInput::Order(input))
             .await
     }
 }

--- a/examples/step/src/main.rs
+++ b/examples/step/src/main.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Enqueue the first step.
-    job.enqueue(Start { n: 42 }).await?;
+    job.enqueue(&Start { n: 42 }).await?;
 
     // Run the job worker.
     job.run().await?;

--- a/examples/tracing/src/main.rs
+++ b/examples/tracing/src/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Enqueue a job task.
     let task_id = job
-        .enqueue(WelcomeEmail {
+        .enqueue(&WelcomeEmail {
             user_id: 42,
             email: "ferris@example.com".to_string(),
             name: "Ferris".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 //!         .await?;
 //!
 //!     // Here we enqueue a new job to be processed later.
-//!     job.enqueue(WelcomeEmail {
+//!     job.enqueue(&WelcomeEmail {
 //!         user_id: 42,
 //!         email: "ferris@example.com".to_string(),
 //!         name: "Ferris".to_string(),
@@ -161,7 +161,7 @@
 //!         .await?;
 //!
 //!     // Enqueue the job for the given order.
-//!     job.enqueue(GenerateReceipt { order_id: 42 }).await?;
+//!     job.enqueue(&GenerateReceipt { order_id: 42 }).await?;
 //!
 //!     // Start processing enqueued jobs.
 //!     job.start().await??;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -595,7 +595,7 @@ mod tests {
 
         // Enqueue a task.
         let task = TestTask;
-        queue.enqueue(&pool, &task, ()).await?;
+        queue.enqueue(&pool, &task, &()).await?;
         assert!(queue.dequeue(&pool).await?.is_some());
 
         // Process the task.
@@ -623,7 +623,7 @@ mod tests {
         let worker = Worker::new(queue.clone(), task.clone());
 
         // Enqueue the task
-        let task_id = queue.enqueue(&pool, &worker.task, ()).await?;
+        let task_id = queue.enqueue(&pool, &worker.task, &()).await?;
 
         // Process the task multiple times to simulate retries
         for retries in 0..3 {
@@ -689,7 +689,7 @@ mod tests {
 
         // Enqueue some tasks now that the worker is listening
         for _ in 0..5 {
-            queue.enqueue(&pool, &LongRunningTask, ()).await?;
+            queue.enqueue(&pool, &LongRunningTask, &()).await?;
         }
 
         // Initiate graceful shutdown
@@ -711,7 +711,7 @@ mod tests {
         assert_eq!(succeeded, Some(5));
 
         // New tasks shouldn't be processed
-        queue.enqueue(&pool, &LongRunningTask, ()).await?;
+        queue.enqueue(&pool, &LongRunningTask, &()).await?;
 
         // Wait to ensure a worker would have seen the new task if one were processing
         tokio::time::sleep(StdDuration::from_secs(1)).await;


### PR DESCRIPTION
This refactors the scheduler to be more like the worker: e.g. it now manages a cancellation token and uses it to manage the shutdown state.

Again similarly to the worker, it listens on the same shutdown channel and upon a notify from postgres will cancel its cancellation token thereby stopping the scheduler.

Coupled with these changes is a breaking change to the queue interface: instead of taking ownership of input, enqueue takes a reference. A similar change should be made for the schedule methods, but that is left out of this patch intentionally.