### PR TITLE
also make schedule methods pass input by reference

### DIFF
--- a/examples/graceful_shutdown/src/main.rs
+++ b/examples/graceful_shutdown/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let every_second = "* * * * * *[America/Los_Angeles]".parse()?;
-    job.schedule(every_second, ()).await?;
+    job.schedule(&every_second, &()).await?;
 
     // Await the shutdown signal handler in its own task.
     tokio::spawn(async move { shutdown_signal(&pool).await });

--- a/examples/scheduled/src/main.rs
+++ b/examples/scheduled/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Schedule the job to run every minute in the given time zone.
     let every_minute = "0 * * * * *[America/Los_Angeles]".parse()?;
-    job.schedule(every_minute, ()).await?;
+    job.schedule(&every_minute, &()).await?;
 
     job.run().await?;
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -607,7 +607,7 @@
 //!
 //! // Sets a weekly schedule with the given input.
 //! let weekly = "@weekly[America/Los_Angeles]".parse()?;
-//! job.schedule(weekly, ()).await?;
+//! job.schedule(&weekly, &()).await?;
 //!
 //! job.start();
 //! # Ok::<(), Box<dyn std::error::Error>>(())
@@ -805,7 +805,7 @@ where
     }
 
     /// Schedule the job using a connection from the queue's pool.
-    pub async fn schedule(&self, zoned_schedule: ZonedSchedule, input: I) -> Result {
+    pub async fn schedule(&self, zoned_schedule: &ZonedSchedule, input: &I) -> Result {
         let mut conn = self.queue.pool.acquire().await?;
         self.schedule_using(&mut *conn, zoned_schedule, input).await
     }
@@ -817,15 +817,15 @@ where
     pub async fn schedule_using<'a, E>(
         &self,
         executor: E,
-        zoned_schedule: ZonedSchedule,
-        input: I,
+        zoned_schedule: &ZonedSchedule,
+        input: &I,
     ) -> Result
     where
         E: PgExecutor<'a>,
     {
-        let job_input = self.first_job_input(&input)?;
+        let job_input = self.first_job_input(input)?;
         self.queue
-            .schedule(executor, zoned_schedule, job_input)
+            .schedule(executor, zoned_schedule, &job_input)
             .await?;
 
         Ok(())
@@ -1626,7 +1626,7 @@ mod tests {
         let monthly = "@monthly[America/Los_Angeles]"
             .parse()
             .expect("A valid zoned scheduled should be provided");
-        job.schedule(monthly, ()).await?;
+        job.schedule(&monthly, &()).await?;
 
         let (schedule, _) = queue
             .task_schedule(&pool)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@
 //!
 //!     // Set a daily schedule with the given input.
 //!     let daily = "@daily[America/Los_Angeles]".parse()?;
-//!     job.schedule(daily, DailyReport).await?;
+//!     job.schedule(&daily, &DailyReport).await?;
 //!
 //!     // Start processing enqueued jobs.
 //!     job.start().await??;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -160,7 +160,7 @@
 //!
 //! // Set a quarter-hour schedule; IANA timezones are mandatory.
 //! let quarter_hour = "0 */15 * * * *[America/Los_Angeles]".parse()?;
-//! queue.schedule(&pool, quarter_hour, ()).await?;
+//! queue.schedule(&pool, &quarter_hour, &()).await?;
 //!
 //! # /*
 //! let task = { /* A type that implements `Task`. */ };
@@ -518,13 +518,13 @@ impl<T: Task> Queue<T> {
     pub async fn schedule<'a, E>(
         &self,
         executor: E,
-        zoned_schedule: ZonedSchedule,
-        input: T::Input,
+        zoned_schedule: &ZonedSchedule,
+        input: &T::Input,
     ) -> Result
     where
         E: PgExecutor<'a>,
     {
-        let input_value = serde_json::to_value(&input)?;
+        let input_value = serde_json::to_value(input)?;
 
         sqlx::query!(
             r#"


### PR DESCRIPTION
This is a follow up to the enqueue changes in #33.