### PR TITLE
rename setter methods

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -1404,10 +1404,10 @@ where
         let job = self.clone();
 
         let mut worker = Worker::new(queue.clone(), job.clone());
-        worker = worker.shutdown_token(shutdown_token.clone());
+        worker.set_shutdown_token(shutdown_token.clone());
 
         let mut scheduler = Scheduler::new(queue, job);
-        scheduler = scheduler.shutdown_token(shutdown_token.clone());
+        scheduler.set_shutdown_token(shutdown_token.clone());
 
         // Spawn the tasks using `tokio::spawn` to decouple them from polling the
         // `Future`.

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -139,22 +139,21 @@ impl<T: Task> Scheduler<T> {
     /// #    .build()
     /// #    .await?;
     /// # let task = ExampleTask;
-    /// # let scheduler = Scheduler::new(queue, task);
+    /// # let mut scheduler = Scheduler::new(queue, task);
     /// # /*
-    /// let scheduler = { /* A `Scheduler`. */ };
+    /// let mut scheduler = { /* A `Scheduler`. */ };
     /// # */
     /// #
     ///
     /// // Set a custom cancellation token.
     /// let token = CancellationToken::new();
-    /// scheduler.shutdown_token(token);
+    /// scheduler.set_shutdown_token(token);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// # }
     /// ```
-    pub fn shutdown_token(mut self, shutdown_token: CancellationToken) -> Self {
+    pub fn set_shutdown_token(&mut self, shutdown_token: CancellationToken) {
         self.shutdown_token = shutdown_token;
-        self
     }
 
     /// Cancels the shutdown token causing the scheduler to exit.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -271,21 +271,20 @@ impl<T: Task + Sync> Worker<T> {
     /// #    .build()
     /// #    .await?;
     /// # let task = ExampleTask;
-    /// # let worker = Worker::new(queue, task);
+    /// # let mut worker = Worker::new(queue, task);
     /// # /*
-    /// let worker = { /* A `Worker`. */ };
+    /// let mut worker = { /* A `Worker`. */ };
     /// # */
     /// #
     ///
     /// // Set a fixed concurrency limit.
-    /// worker.concurrency_limit(32);
+    /// worker.set_concurrency_limit(32);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// # }
     /// ```
-    pub fn concurrency_limit(mut self, concurrency_limit: usize) -> Self {
+    pub fn set_concurrency_limit(&mut self, concurrency_limit: usize) {
         self.concurrency_limit = concurrency_limit;
-        self
     }
 
     /// Sets the shutdown token.
@@ -320,22 +319,21 @@ impl<T: Task + Sync> Worker<T> {
     /// #    .build()
     /// #    .await?;
     /// # let task = ExampleTask;
-    /// # let worker = Worker::new(queue, task);
+    /// # let mut worker = Worker::new(queue, task);
     /// # /*
-    /// let worker = { /* A `Worker`. */ };
+    /// let mut worker = { /* A `Worker`. */ };
     /// # */
     /// #
     ///
     /// // Set a custom cancellation token.
     /// let token = CancellationToken::new();
-    /// worker.shutdown_token(token);
+    /// worker.set_shutdown_token(token);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// # });
     /// # }
     /// ```
-    pub fn shutdown_token(mut self, shutdown_token: CancellationToken) -> Self {
+    pub fn set_shutdown_token(&mut self, shutdown_token: CancellationToken) {
         self.shutdown_token = shutdown_token;
-        self
     }
 
     /// Cancels the shutdown token and begins a graceful shutdown of in-progress


### PR DESCRIPTION
This renames the setters on workers and schedulers to follow the standard convention.

While this is a breaking change, we don't plan to follow proper semver until 0.1.x, so rather than deprecate we've simply renamed.