### PR TITLE
isolate underway migrations

### DIFF
--- a/.sqlx/query-03c2ac38e6ec2801eed7e5b19076eafcc589f32e2424460b0c345e6c477a1b28.json
+++ b/.sqlx/query-03c2ac38e6ec2801eed7e5b19076eafcc589f32e2424460b0c345e6c477a1b28.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "create schema if not exists underway;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "03c2ac38e6ec2801eed7e5b19076eafcc589f32e2424460b0c345e6c477a1b28"
+}

--- a/.sqlx/query-2584080f8ca262aa7526dde00a50ae125a6a8e52f4fc76d05d15f2c6f663d1cd.json
+++ b/.sqlx/query-2584080f8ca262aa7526dde00a50ae125a6a8e52f4fc76d05d15f2c6f663d1cd.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select exists (\n              select 1 from pg_namespace where nspname = 'underway'\n            );\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "2584080f8ca262aa7526dde00a50ae125a6a8e52f4fc76d05d15f2c6f663d1cd"
+}

--- a/.sqlx/query-ccf314910c001d4933326838f507380d36a50d63778ed5589d7ffe0fe9f60db3.json
+++ b/.sqlx/query-ccf314910c001d4933326838f507380d36a50d63778ed5589d7ffe0fe9f60db3.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "set local search_path to underway;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "ccf314910c001d4933326838f507380d36a50d63778ed5589d7ffe0fe9f60db3"
+}

--- a/.sqlx/query-f069227d261bdec30ade8d0553bffc2796c3f4914f773ef569526feb0c7062ea.json
+++ b/.sqlx/query-f069227d261bdec30ade8d0553bffc2796c3f4914f773ef569526feb0c7062ea.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select exists (\n                select 1 from information_schema.tables\n                where table_schema = 'underway' and \n                      table_name = '_sqlx_migrations'\n            );\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "f069227d261bdec30ade8d0553bffc2796c3f4914f773ef569526feb0c7062ea"
+}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = PgPool::connect(database_url).await?;
 
     // Run migrations.
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     // Build the job.
     let job = Job::builder()
@@ -148,7 +148,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = PgPool::connect(database_url).await?;
 
     // Run migrations.
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     // Build the job.
     let job = Job::builder()
@@ -207,7 +207,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = PgPool::connect(database_url).await?;
 
     // Run migrations.
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     // Build the job.
     let job = Job::builder()

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = PgPool::connect(database_url).await?;
 
     // Run migrations.
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     // Build the job.
     let job = Job::builder()

--- a/examples/graceful_shutdown/src/main.rs
+++ b/examples/graceful_shutdown/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Run migrations.
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     // Build the job.
     let job = Job::builder()

--- a/examples/multitask/src/main.rs
+++ b/examples/multitask/src/main.rs
@@ -155,7 +155,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = PgPool::connect(database_url).await?;
 
     // Run migrations.
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     // Create the task queue.
     let queue = Queue::builder()

--- a/examples/rag/src/main.rs
+++ b/examples/rag/src/main.rs
@@ -152,7 +152,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let database_url = &env::var("DATABASE_URL").expect("DATABASE_URL should be set");
     let pool = PgPool::connect(database_url).await?;
 
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     let openai_client = Client::new();
 

--- a/examples/scheduled/src/main.rs
+++ b/examples/scheduled/src/main.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = PgPool::connect(&database_url).await?;
 
     // Run migrations.
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     // Build the job.
     let job = Job::builder()

--- a/examples/step/src/main.rs
+++ b/examples/step/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = PgPool::connect(database_url).await?;
 
     // Run migrations.
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     // Create our job.
     let job = Job::builder()

--- a/examples/tracing/src/main.rs
+++ b/examples/tracing/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = PgPool::connect(database_url).await?;
 
     // Run migrations.
-    underway::MIGRATOR.run(&pool).await?;
+    underway::run_migrations(&pool).await?;
 
     // Build the job.
     let job = Job::builder()

--- a/migrations/20240921151751_0.sql
+++ b/migrations/20240921151751_0.sql
@@ -1,5 +1,9 @@
 create schema if not exists underway;
 
+-- Manage Underway migrations within the Underway schema.
+create table if not exists underway._sqlx_migrations
+(like public._sqlx_migrations including all);
+
 create table underway.task_queue (
     name       text not null,
     dlq_name   text,


### PR DESCRIPTION
This is something of a hack to work around the fact that SQLx migrations do not currently support specifying a schema under which the migrations table will live.

Here we provide a search path throughout our migrations and in the transaction that will run the migrations to ensure that migrations are applied to `underway._sqlx_migrations`. Note that this assumes a `public._sqlx_migrations` exists.

In the future we should be able to use `sqlx.toml` to address this more robustly. That's expected as part of the `0.9.0` release of SQLx. Please see: https://github.com/launchbadge/sqlx/pull/3383

Closes #11