### PR TITLE
provide an enqueued job type

### DIFF
--- a/.sqlx/query-0d302d44aacf1e8ee3233b8c4814e7355fc4b57d98550cd43aec5c424ac4cdca.json
+++ b/.sqlx/query-0d302d44aacf1e8ee3233b8c4814e7355fc4b57d98550cd43aec5c424ac4cdca.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select state as \"state: TaskState\"\n            from underway.task\n            where input->>'job_id' = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "state: TaskState",
+        "type_info": {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0d302d44aacf1e8ee3233b8c4814e7355fc4b57d98550cd43aec5c424ac4cdca"
+}

--- a/.sqlx/query-2692ae7a5cce9ed6fb444259dce61d6cc4b34794d25cdbc3eec820abd807de00.json
+++ b/.sqlx/query-2692ae7a5cce9ed6fb444259dce61d6cc4b34794d25cdbc3eec820abd807de00.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select id\n            from underway.task\n            where input->>'job_id' = $1 and\n                  state = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2692ae7a5cce9ed6fb444259dce61d6cc4b34794d25cdbc3eec820abd807de00"
+}

--- a/src/job.rs
+++ b/src/job.rs
@@ -728,7 +728,7 @@ mod sealed {
     pub struct JobState {
         pub step_index: usize,
         pub step_input: serde_json::Value,
-        pub job_id: JobId,
+        pub(crate) job_id: JobId,
     } // TODO: Versioning?
 }
 
@@ -790,7 +790,7 @@ impl Future for JobHandle {
 /// tasks on the queue. This means that each task related to a job will have
 /// the same job ID.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
-pub struct JobId(Uuid);
+pub(crate) struct JobId(Uuid);
 
 impl JobId {
     fn new() -> Self {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -932,7 +932,6 @@ impl<T: Task> Queue<T> {
         Ok(())
     }
 
-    #[allow(dead_code)] // TODO: Revisit cancellation re jobs.
     pub(crate) async fn mark_task_cancelled<'a, E>(&self, executor: E, task_id: TaskId) -> Result
     where
         E: PgExecutor<'a>,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -932,7 +932,11 @@ impl<T: Task> Queue<T> {
         Ok(())
     }
 
-    pub(crate) async fn mark_task_cancelled<'a, E>(&self, executor: E, task_id: TaskId) -> Result
+    pub(crate) async fn mark_task_cancelled<'a, E>(
+        &self,
+        executor: E,
+        task_id: TaskId,
+    ) -> Result<bool>
     where
         E: PgExecutor<'a>,
     {
@@ -954,7 +958,7 @@ impl<T: Task> Queue<T> {
             return Err(Error::TaskNotFound(task_id));
         }
 
-        Ok(())
+        Ok(result.rows_affected() > 0)
     }
 
     pub(crate) async fn mark_task_succeeded<'a, E>(&self, executor: E, task_id: TaskId) -> Result


### PR DESCRIPTION
This introduces a type that's returned from enqueuing a job and specifically replaces the task ID. By doing so, we also enable job cancellation.

Additional methods, providing e.g. deletion or resumption, can be added in future as well.

Lastly `Future` could be implemented for this type. Assuming an implementation that polls the status of the job's completion, this could be optionally awaited to ensure a specific job has reached a completed state.