### PR TITLE
use newtype for task id

### DIFF
--- a/.sqlx/query-a55bfd24f1ca171d27491593b8e96d78ee50e376d08e1a7a873048d7468638d8.json
+++ b/.sqlx/query-a55bfd24f1ca171d27491593b8e96d78ee50e376d08e1a7a873048d7468638d8.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select state as \"state: TaskState\" from underway.task where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "state: TaskState",
+        "type_info": {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a55bfd24f1ca171d27491593b8e96d78ee50e376d08e1a7a873048d7468638d8"
+}

--- a/.sqlx/query-c3b4d8c60a953915625f12731554c46ae4ae17bc0d01d91a214da652b2535f58.json
+++ b/.sqlx/query-c3b4d8c60a953915625f12731554c46ae4ae17bc0d01d91a214da652b2535f58.json
@@ -1,11 +1,11 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select\n              id,\n              input,\n              timeout,\n              retry_count,\n              max_attempts,\n              initial_interval_ms,\n              max_interval_ms,\n              backoff_coefficient,\n              concurrency_key\n            from underway.task\n            where task_queue_name = $1\n              and state = $2\n              and created_at + delay <= now()\n            order by priority desc, created_at, id\n            limit 1\n            for update skip locked\n            ",
+  "query": "\n            select\n              id as \"id: TaskId\",\n              input,\n              timeout,\n              retry_count,\n              max_attempts,\n              initial_interval_ms,\n              max_interval_ms,\n              backoff_coefficient,\n              concurrency_key\n            from underway.task\n            where task_queue_name = $1\n              and state = $2\n              and created_at + delay <= now()\n            order by priority desc, created_at, id\n            limit 1\n            for update skip locked\n            ",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
-        "name": "id",
+        "name": "id: TaskId",
         "type_info": "Uuid"
       },
       {
@@ -80,5 +80,5 @@
       true
     ]
   },
-  "hash": "27ea7bbeb9f9270fd6721129a480438c17a32cc5e9b366026aebb09f426beba7"
+  "hash": "c3b4d8c60a953915625f12731554c46ae4ae17bc0d01d91a214da652b2535f58"
 }

--- a/.sqlx/query-e6a0949430cf67fb2452bf41533d402338b3afbbef23785c8460ecc2c00cd5a3.json
+++ b/.sqlx/query-e6a0949430cf67fb2452bf41533d402338b3afbbef23785c8460ecc2c00cd5a3.json
@@ -1,11 +1,11 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select id\n            from underway.task\n            where input->>'job_id' = $1 and\n                  state = $2\n            ",
+  "query": "\n            select id as \"id: TaskId\"\n            from underway.task\n            where input->>'job_id' = $1 and\n                  state = $2\n            ",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
-        "name": "id",
+        "name": "id: TaskId",
         "type_info": "Uuid"
       }
     ],
@@ -32,5 +32,5 @@
       false
     ]
   },
-  "hash": "2692ae7a5cce9ed6fb444259dce61d6cc4b34794d25cdbc3eec820abd807de00"
+  "hash": "e6a0949430cf67fb2452bf41533d402338b3afbbef23785c8460ecc2c00cd5a3"
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -131,7 +131,7 @@ use tracing::instrument;
 
 use crate::{
     queue::{acquire_advisory_xact_lock, Error as QueueError, Queue, SHUTDOWN_CHANNEL},
-    task::{DequeuedTask, Error as TaskError, Id as TaskId, RetryCount, RetryPolicy, Task},
+    task::{DequeuedTask, Error as TaskError, RetryCount, RetryPolicy, Task, TaskId},
 };
 pub(crate) type Result<T = ()> = std::result::Result<T, Error>;
 
@@ -972,7 +972,7 @@ mod tests {
             from underway.task
             where id = $1
             "#,
-            task_id
+            task_id as _
         )
         .fetch_one(&pool)
         .await?;


### PR DESCRIPTION
Following from changes to the job ID, here we make the task ID as a newtype.