### PR TITLE
refactor dequeue transaction handling

### DIFF
--- a/.sqlx/query-167170ec018c32a7c9238ab95490dccb8d22d4591ba8920691213829c0a11622.json
+++ b/.sqlx/query-167170ec018c32a7c9238ab95490dccb8d22d4591ba8920691213829c0a11622.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            update underway.task\n            set state = $3, last_attempt_at = now()\n            where id = (\n                select id\n                from underway.task\n                where task_queue_name = $1\n                  and (\n                      state = $2\n                      or (state = $3 and last_heartbeat_at < now() - heartbeat)\n                    )\n                  and created_at + delay <= now()\n                order by\n                  priority desc,\n                  created_at,\n                  id\n                limit 1\n                for update skip locked\n            )\n            returning\n                id as \"id: TaskId\",\n                task_queue_name as \"queue_name\",\n                input,\n                timeout,\n                heartbeat,\n                retry_policy as \"retry_policy: RetryPolicy\",\n                concurrency_key\n            ",
+  "query": "\n            update underway.task\n            set state = $3,\n                last_attempt_at = now(),\n                last_heartbeat_at = now()\n            where id = (\n                select id\n                from underway.task\n                where task_queue_name = $1\n                  and (\n                      state = $2\n                      or (state = $3 and last_heartbeat_at < now() - heartbeat)\n                    )\n                  and created_at + delay <= now()\n                order by\n                  priority desc,\n                  created_at,\n                  id\n                limit 1\n                for update skip locked\n            )\n            returning\n                id as \"id: TaskId\",\n                task_queue_name as \"queue_name\",\n                input,\n                timeout,\n                heartbeat,\n                retry_policy as \"retry_policy: RetryPolicy\",\n                concurrency_key\n            ",
   "describe": {
     "columns": [
       {
@@ -106,5 +106,5 @@
       true
     ]
   },
-  "hash": "d726027de5fc4369abc0bc76f0ce0ec74f97447850cebdebba1c0748059ce17e"
+  "hash": "167170ec018c32a7c9238ab95490dccb8d22d4591ba8920691213829c0a11622"
 }

--- a/.sqlx/query-24e7b0c00cda5634d04fe27cb833f12803108d0b4235d39fe372acd4b364d99d.json
+++ b/.sqlx/query-24e7b0c00cda5634d04fe27cb833f12803108d0b4235d39fe372acd4b364d99d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            update underway.task\n            set state = $3, last_attempt_at = now()\n            where id = (\n                select id\n                from underway.task\n                where task_queue_name = $1\n                  and state = $2\n                  and created_at + delay <= now()\n                order by priority desc, created_at, id\n                limit 1\n                for update skip locked\n            )\n            returning\n                id as \"id: TaskId\",\n                task_queue_name as \"queue_name\",\n                input,\n                timeout,\n                retry_policy as \"retry_policy: RetryPolicy\",\n                concurrency_key\n            ",
+  "query": "\n            select\n              id as \"id: TaskId\",\n              task_queue_name as \"queue_name\",\n              input,\n              retry_policy as \"retry_policy: RetryPolicy\",\n              timeout,\n              heartbeat,\n              concurrency_key\n            from underway.task\n            where input->>'job_id' = $1\n              and state = $2\n            ",
   "describe": {
     "columns": [
       {
@@ -20,11 +20,6 @@
       },
       {
         "ordinal": 3,
-        "name": "timeout",
-        "type_info": "Interval"
-      },
-      {
-        "ordinal": 4,
         "name": "retry_policy: RetryPolicy",
         "type_info": {
           "Custom": {
@@ -53,7 +48,17 @@
         }
       },
       {
+        "ordinal": 4,
+        "name": "timeout",
+        "type_info": "Interval"
+      },
+      {
         "ordinal": 5,
+        "name": "heartbeat",
+        "type_info": "Interval"
+      },
+      {
+        "ordinal": 6,
         "name": "concurrency_key",
         "type_info": "Text"
       }
@@ -61,20 +66,6 @@
     "parameters": {
       "Left": [
         "Text",
-        {
-          "Custom": {
-            "name": "underway.task_state",
-            "kind": {
-              "Enum": [
-                "pending",
-                "in_progress",
-                "succeeded",
-                "cancelled",
-                "failed"
-              ]
-            }
-          }
-        },
         {
           "Custom": {
             "name": "underway.task_state",
@@ -97,8 +88,9 @@
       false,
       false,
       false,
+      false,
       true
     ]
   },
-  "hash": "705e4322b77ede1818f4cda7d50141b623908a7c980a09dbe8a3ad40c84fae7e"
+  "hash": "24e7b0c00cda5634d04fe27cb833f12803108d0b4235d39fe372acd4b364d99d"
 }

--- a/.sqlx/query-9731fc6ba31c2cc1bd00b8e177c44ca85285a2606f9485a9f38a3585ce48b00b.json
+++ b/.sqlx/query-9731fc6ba31c2cc1bd00b8e177c44ca85285a2606f9485a9f38a3585ce48b00b.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            update underway.task\n            set updated_at = now(),\n                last_heartbeat_at = now()\n            where id = $1\n              and task_queue_name = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9731fc6ba31c2cc1bd00b8e177c44ca85285a2606f9485a9f38a3585ce48b00b"
+}

--- a/.sqlx/query-98aa8d56e8fb6d28480105370b0b6a6d3e68e0e64bdeeed97a04e7597aa43853.json
+++ b/.sqlx/query-98aa8d56e8fb6d28480105370b0b6a6d3e68e0e64bdeeed97a04e7597aa43853.json
@@ -1,12 +1,12 @@
 {
   "db_name": "PostgreSQL",
-  "query": "select pg_advisory_xact_lock(hashtext($1))",
+  "query": "select pg_try_advisory_xact_lock(hashtext($1))",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
-        "name": "pg_advisory_xact_lock",
-        "type_info": "Void"
+        "name": "pg_try_advisory_xact_lock",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -18,5 +18,5 @@
       null
     ]
   },
-  "hash": "e31efccd3da03c27df3b249503901d1b95832cd005b3f70ab958b654087b388c"
+  "hash": "98aa8d56e8fb6d28480105370b0b6a6d3e68e0e64bdeeed97a04e7597aa43853"
 }

--- a/.sqlx/query-d726027de5fc4369abc0bc76f0ce0ec74f97447850cebdebba1c0748059ce17e.json
+++ b/.sqlx/query-d726027de5fc4369abc0bc76f0ce0ec74f97447850cebdebba1c0748059ce17e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select\n              id as \"id: TaskId\",\n              task_queue_name as \"queue_name\",\n              input,\n              retry_policy as \"retry_policy: RetryPolicy\",\n              timeout,\n              concurrency_key\n            from underway.task\n            where input->>'job_id' = $1\n              and state = $2\n            ",
+  "query": "\n            update underway.task\n            set state = $3, last_attempt_at = now()\n            where id = (\n                select id\n                from underway.task\n                where task_queue_name = $1\n                  and (\n                      state = $2\n                      or (state = $3 and last_heartbeat_at < now() - heartbeat)\n                    )\n                  and created_at + delay <= now()\n                order by\n                  priority desc,\n                  created_at,\n                  id\n                limit 1\n                for update skip locked\n            )\n            returning\n                id as \"id: TaskId\",\n                task_queue_name as \"queue_name\",\n                input,\n                timeout,\n                heartbeat,\n                retry_policy as \"retry_policy: RetryPolicy\",\n                concurrency_key\n            ",
   "describe": {
     "columns": [
       {
@@ -20,6 +20,16 @@
       },
       {
         "ordinal": 3,
+        "name": "timeout",
+        "type_info": "Interval"
+      },
+      {
+        "ordinal": 4,
+        "name": "heartbeat",
+        "type_info": "Interval"
+      },
+      {
+        "ordinal": 5,
         "name": "retry_policy: RetryPolicy",
         "type_info": {
           "Custom": {
@@ -48,12 +58,7 @@
         }
       },
       {
-        "ordinal": 4,
-        "name": "timeout",
-        "type_info": "Interval"
-      },
-      {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "concurrency_key",
         "type_info": "Text"
       }
@@ -61,6 +66,20 @@
     "parameters": {
       "Left": [
         "Text",
+        {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        },
         {
           "Custom": {
             "name": "underway.task_state",
@@ -83,8 +102,9 @@
       false,
       false,
       false,
+      false,
       true
     ]
   },
-  "hash": "fa13a4875b569ce138438632ab68c60ec62e001cbe007b9a75776cf54e21f9cc"
+  "hash": "d726027de5fc4369abc0bc76f0ce0ec74f97447850cebdebba1c0748059ce17e"
 }

--- a/migrations/20241110164319_3.sql
+++ b/migrations/20241110164319_3.sql
@@ -1,0 +1,8 @@
+-- Force anything running this migration to use the right search path.
+set local search_path to underway;
+
+alter table underway.task
+add column if not exists heartbeat interval not null default interval '30 seconds';
+
+alter table underway.task
+add column if not exists last_heartbeat_at timestamp with time zone;

--- a/src/job.rs
+++ b/src/job.rs
@@ -901,6 +901,7 @@ impl<T: Task> EnqueuedJob<T> {
               input,
               retry_policy as "retry_policy: RetryPolicy",
               timeout,
+              heartbeat,
               concurrency_key
             from underway.task
             where input->>'job_id' = $1
@@ -2375,9 +2376,8 @@ mod tests {
         };
         job.enqueue(&input).await?;
 
-        let mut conn = pool.acquire().await?;
         let pending_task = queue
-            .dequeue(&mut conn)
+            .dequeue()
             .await?
             .expect("There should be an enqueued task");
 
@@ -2415,9 +2415,8 @@ mod tests {
         };
         job.enqueue(&input).await?;
 
-        let mut conn = pool.acquire().await?;
         let pending_task = queue
-            .dequeue(&mut conn)
+            .dequeue()
             .await?
             .expect("There should be an enqueued task");
 
@@ -2467,9 +2466,8 @@ mod tests {
         };
         job.enqueue(&input).await?;
 
-        let mut conn = pool.acquire().await?;
         let pending_task = queue
-            .dequeue(&mut conn)
+            .dequeue()
             .await?
             .expect("There should be an enqueued task");
 
@@ -2565,9 +2563,8 @@ mod tests {
         };
         job.enqueue(&input).await?;
 
-        let mut conn = pool.acquire().await?;
         let pending_task = queue
-            .dequeue(&mut conn)
+            .dequeue()
             .await?
             .expect("There should be an enqueued task");
 
@@ -2604,9 +2601,8 @@ mod tests {
         };
         job.enqueue(&input).await?;
 
-        let mut conn = pool.acquire().await?;
         let pending_task = queue
-            .dequeue(&mut conn)
+            .dequeue()
             .await?
             .expect("There should be an enqueued task");
 
@@ -2694,9 +2690,8 @@ mod tests {
         worker.process_next_task().await?;
 
         // Inspect the second task.
-        let mut conn = pool.acquire().await?;
         let pending_task = queue
-            .dequeue(&mut conn)
+            .dequeue()
             .await?
             .expect("There should be an enqueued task");
 
@@ -2758,8 +2753,7 @@ mod tests {
         let enqueued_job = job.enqueue(&input).await?;
 
         // Dequeue the first task.
-        let mut conn = pool.acquire().await?;
-        let Some(dequeued_task) = queue.dequeue(&mut conn).await? else {
+        let Some(dequeued_task) = queue.dequeue().await? else {
             panic!("Task should exist");
         };
 
@@ -2793,8 +2787,7 @@ mod tests {
         worker.process_next_task().await?;
 
         // Dequeue the second task.
-        let mut conn = pool.acquire().await?;
-        let Some(dequeued_task) = queue.dequeue(&mut conn).await? else {
+        let Some(dequeued_task) = queue.dequeue().await? else {
             panic!("Next task should exist");
         };
 
@@ -2861,9 +2854,8 @@ mod tests {
         worker.process_next_task().await?;
 
         // Inspect the second task.
-        let mut conn = pool.acquire().await?;
         let pending_task = queue
-            .dequeue(&mut conn)
+            .dequeue()
             .await?
             .expect("There should be an enqueued task");
 
@@ -2917,8 +2909,7 @@ mod tests {
         let enqueued_job = job.enqueue(&input).await?;
 
         // Dequeue the first task.
-        let mut conn = pool.acquire().await?;
-        let Some(dequeued_task) = queue.dequeue(&mut conn).await? else {
+        let Some(dequeued_task) = queue.dequeue().await? else {
             panic!("Task should exist");
         };
 
@@ -2961,8 +2952,7 @@ mod tests {
         worker.process_next_task().await?;
 
         // Dequeue the second task.
-        let mut conn = pool.acquire().await?;
-        let Some(dequeued_task) = queue.dequeue(&mut conn).await? else {
+        let Some(dequeued_task) = queue.dequeue().await? else {
             panic!("Next task should exist");
         };
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -645,7 +645,9 @@ impl<T: Task> Queue<T> {
             InProgressTask,
             r#"
             update underway.task
-            set state = $3, last_attempt_at = now()
+            set state = $3,
+                last_attempt_at = now(),
+                last_heartbeat_at = now()
             where id = (
                 select id
                 from underway.task

--- a/src/task.rs
+++ b/src/task.rs
@@ -432,6 +432,47 @@ pub trait Task: Send + 'static {
         Span::new()
     }
 
+    /// Specifies interval on which the task's heartbeat timestamp should be
+    /// updated.
+    ///
+    /// This is used by workers to update the task row with the current
+    /// timestamp. Doing so makes it possible to detect tasks that may have
+    /// become stuck, for example because a worker crashed or otherwise
+    /// didn't exit cleanly.
+    ///
+    /// The default is 30 seconds.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jiff::{Span, ToSpan};
+    /// use sqlx::{Postgres, Transaction};
+    /// use underway::{task::Result as TaskResult, Task};
+    ///
+    /// struct LivelyTask;
+    ///
+    /// impl Task for LivelyTask {
+    ///     type Input = ();
+    ///     type Output = ();
+    ///
+    ///     async fn execute(
+    ///         &self,
+    ///         _tx: Transaction<'_, Postgres>,
+    ///         _input: Self::Input,
+    ///     ) -> TaskResult<Self::Output> {
+    ///         Ok(())
+    ///     }
+    ///
+    ///     // Set the heartbeat interval to 1 second.
+    ///     fn heartbeat(&self) -> Span {
+    ///         1.second()
+    ///     }
+    /// }
+    /// ```
+    fn heartbeat(&self) -> Span {
+        30.seconds()
+    }
+
     /// Provides an optional concurrency key for the task.
     ///
     /// Concurrency keys are used to limit how many tasks of a specific type are


### PR DESCRIPTION
This refactor encapsulates pending task dequeue operations within their own transactions, updating the task row state to prevent duplicate processing by other callers. By doing so, we ensure that state changes are immediately visible, accurately reflecting task ownership throughout its processing lifecycle.

Additionally, tasks now include a configurable heartbeat interval and a record of the last heartbeat. Workers periodically update the task row to indicate ongoing liveness. Should a task’s heartbeat become stale, the dequeue method can select it for reassignment.

It's important to note that a missed heartbeat alone does not definitively indicate task abandonment, as a worker might resume processing after a temporary delay. To guard against this type of partial failure, workers also acquire a transaction-level advisory lock on the task ID. As long as a worker's transaction remains active, this lock prevents other workers from processing the same task, ensuring exclusive ownership and consistent processing even across intermittent failures.

A notable benefit of these changes is that task progress states are fully utilized and in-progress tasks are visible globally. Furthermore, transaction overhead is reduced as a dequeue's transaction is only held for the duration of obtaining an available task. That said, a second transaction is still maintained for the duration of execution so long-running tasks still benefit from decomposition into e.g. multiple job steps.