### PR TITLE
record heartbeat in a separate task

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -978,7 +978,7 @@ impl<T: Task> Queue<T> {
 /// manage state transitions as they process the task. In fact, all valid state
 /// transitions are encapsulated by it and this is the only interface through
 /// which task state should be altered.
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct InProgressTask {
     pub(crate) id: TaskId,
     pub(crate) queue_name: String,


### PR DESCRIPTION
This fixes an issue where we were:

1. Not using an interval and therefore only waiting one time to send a heartbeat,
2. Cancelling the other select futures as a side effect of incorporating the heartbeat.

So to address these issues, we use a separate task entirely to record heartbeats.