### PR TITLE
stale dequeues consider retries

### DIFF
--- a/.sqlx/query-56a0f6c70e41d1b89d0b16a4cbbb989aa3da718f76f4f4abf8794e538c4ed2b8.json
+++ b/.sqlx/query-56a0f6c70e41d1b89d0b16a4cbbb989aa3da718f76f4f4abf8794e538c4ed2b8.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                update underway.task_attempt\n                set state = $3\n                where task_id = $1\n                  and task_queue_name = $2\n                  and state = $4\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "56a0f6c70e41d1b89d0b16a4cbbb989aa3da718f76f4f4abf8794e538c4ed2b8"
+}

--- a/.sqlx/query-910aaa339267667a5184c82f628b2f744c70fce710c52ea542f38eff0d7100e5.json
+++ b/.sqlx/query-910aaa339267667a5184c82f628b2f744c70fce710c52ea542f38eff0d7100e5.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            update underway.task\n            set state = $3,\n                last_attempt_at = now(),\n                last_heartbeat_at = now()\n            where id = (\n                select id\n                from underway.task\n                where task_queue_name = $1\n                  and (\n                      state = $2\n                      or (state = $3 and last_heartbeat_at < now() - heartbeat)\n                    )\n                  and created_at + delay <= now()\n                order by\n                  priority desc,\n                  created_at,\n                  id\n                limit 1\n                for update skip locked\n            )\n            returning\n                id as \"id: TaskId\",\n                task_queue_name as \"queue_name\",\n                input,\n                timeout,\n                heartbeat,\n                retry_policy as \"retry_policy: RetryPolicy\",\n                concurrency_key\n            ",
+  "query": "\n            with selected_task as (\n                select id\n                from underway.task\n                where task_queue_name = $1\n                  and (\n                      state = $2\n                      -- See if there are any available stalled tasks.\n                      or (\n                          state = $3\n                          -- Has heartbeat stalled?\n                          and last_heartbeat_at < now() - heartbeat\n                          -- Are there remaining retries?\n                          and (retry_policy).max_attempts > (\n                              select count(*)\n                              from underway.task_attempt\n                              where task_id = id\n                                and task_queue_name = $1\n                          )\n                      )\n                  )\n                  and created_at + delay <= now()\n                order by\n                  priority desc,\n                  created_at,\n                  id\n                limit 1\n                for update skip locked\n            )\n            update underway.task\n            set state = $3,\n                last_attempt_at = now(),\n                last_heartbeat_at = now()\n            from selected_task\n            where underway.task.id = selected_task.id\n            returning\n                underway.task.id as \"id: TaskId\",\n                task_queue_name as \"queue_name\",\n                input,\n                timeout,\n                heartbeat,\n                retry_policy as \"retry_policy: RetryPolicy\",\n                concurrency_key\n            ",
   "describe": {
     "columns": [
       {
@@ -106,5 +106,5 @@
       true
     ]
   },
-  "hash": "167170ec018c32a7c9238ab95490dccb8d22d4591ba8920691213829c0a11622"
+  "hash": "910aaa339267667a5184c82f628b2f744c70fce710c52ea542f38eff0d7100e5"
 }

--- a/.sqlx/query-a288070a7d1f34fd78d382dc3757557b3f674dd9c46067ed80232cbfbbd56a98.json
+++ b/.sqlx/query-a288070a7d1f34fd78d382dc3757557b3f674dd9c46067ed80232cbfbbd56a98.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select state as \"state: TaskState\"\n            from underway.task_attempt\n            where task_id = $1 and state = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "state: TaskState",
+        "type_info": {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        {
+          "Custom": {
+            "name": "underway.task_state",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "succeeded",
+                "cancelled",
+                "failed"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a288070a7d1f34fd78d382dc3757557b3f674dd9c46067ed80232cbfbbd56a98"
+}


### PR DESCRIPTION
This fixes an issue where dequeuing a stall retry would not consider if the related task had available retries or not.

To address this we rework the dequeue query to check the retry record directly as part of the condition for selecting a stale task.

We also provide an update over attempt rows when a task row is selected to ensure that prior in-progress attempts are marked as failed.