### PR TITLE
ensure task heartbeat is set upon enqueue

### DIFF
--- a/.sqlx/query-0ba3e34a0223cf00d4724fc2502f0565ac0ea1aad6b5bbbf92ea433d0bfe2fa8.json
+++ b/.sqlx/query-0ba3e34a0223cf00d4724fc2502f0565ac0ea1aad6b5bbbf92ea433d0bfe2fa8.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                select last_heartbeat_at as \"last_heartbeat_at: i64\"\n                from underway.task\n                where id = $1\n                  and task_queue_name = $2\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "last_heartbeat_at: i64",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "0ba3e34a0223cf00d4724fc2502f0565ac0ea1aad6b5bbbf92ea433d0bfe2fa8"
+}

--- a/.sqlx/query-1174e23b60bd4457c8a8e01f7c94b6f0bda5f2e586e7bb2b6ff3edc7d7d02648.json
+++ b/.sqlx/query-1174e23b60bd4457c8a8e01f7c94b6f0bda5f2e586e7bb2b6ff3edc7d7d02648.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select delay \n            from underway.task\n            where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "delay",
+        "type_info": "Interval"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1174e23b60bd4457c8a8e01f7c94b6f0bda5f2e586e7bb2b6ff3edc7d7d02648"
+}

--- a/.sqlx/query-1be5549d9c124a1cde65483e2d218101cb21ba3d1d348b5d636c704ca3904722.json
+++ b/.sqlx/query-1be5549d9c124a1cde65483e2d218101cb21ba3d1d348b5d636c704ca3904722.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select retry_policy as \"retry_policy: RetryPolicy\" \n            from underway.task\n            where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "retry_policy: RetryPolicy",
+        "type_info": {
+          "Custom": {
+            "name": "underway.task_retry_policy",
+            "kind": {
+              "Composite": [
+                [
+                  "max_attempts",
+                  "Int4"
+                ],
+                [
+                  "initial_interval_ms",
+                  "Int4"
+                ],
+                [
+                  "max_interval_ms",
+                  "Int4"
+                ],
+                [
+                  "backoff_coefficient",
+                  "Float8"
+                ]
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1be5549d9c124a1cde65483e2d218101cb21ba3d1d348b5d636c704ca3904722"
+}

--- a/.sqlx/query-4ff1463f0b262754a66e35e3b55037d9da622cb38961924d38f4c87fbcf1b169.json
+++ b/.sqlx/query-4ff1463f0b262754a66e35e3b55037d9da622cb38961924d38f4c87fbcf1b169.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select timeout \n            from underway.task\n            where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "timeout",
+        "type_info": "Interval"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "4ff1463f0b262754a66e35e3b55037d9da622cb38961924d38f4c87fbcf1b169"
+}

--- a/.sqlx/query-56d62d8d964df1492d1e475e4e4602e811be0a02391b1acb4c687d11e9680795.json
+++ b/.sqlx/query-56d62d8d964df1492d1e475e4e4602e811be0a02391b1acb4c687d11e9680795.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select priority\n            from underway.task\n            where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "56d62d8d964df1492d1e475e4e4602e811be0a02391b1acb4c687d11e9680795"
+}

--- a/.sqlx/query-75427f58e86684d74b46fedfb5a3612f29270fe025f6d8e4bf9a4445656af703.json
+++ b/.sqlx/query-75427f58e86684d74b46fedfb5a3612f29270fe025f6d8e4bf9a4445656af703.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select concurrency_key\n            from underway.task\n            where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "concurrency_key",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "75427f58e86684d74b46fedfb5a3612f29270fe025f6d8e4bf9a4445656af703"
+}

--- a/.sqlx/query-c1d1c129a916b8b8c4d997667afb43d5ae15b75d543fca14a6c17e41c7200dce.json
+++ b/.sqlx/query-c1d1c129a916b8b8c4d997667afb43d5ae15b75d543fca14a6c17e41c7200dce.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select ttl \n            from underway.task\n            where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "ttl",
+        "type_info": "Interval"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c1d1c129a916b8b8c4d997667afb43d5ae15b75d543fca14a6c17e41c7200dce"
+}

--- a/.sqlx/query-dae0ef841b214a8f0d3981f27aa490d09dd5db2962112316ae892a59fc7f152c.json
+++ b/.sqlx/query-dae0ef841b214a8f0d3981f27aa490d09dd5db2962112316ae892a59fc7f152c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            insert into underway.task (\n              id,\n              task_queue_name,\n              input,\n              timeout,\n              ttl,\n              delay,\n              retry_policy,\n              concurrency_key,\n              priority\n            ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n            ",
+  "query": "\n            insert into underway.task (\n              id,\n              task_queue_name,\n              input,\n              timeout,\n              heartbeat,\n              ttl,\n              delay,\n              retry_policy,\n              concurrency_key,\n              priority\n            ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)\n            ",
   "describe": {
     "columns": [],
     "parameters": {
@@ -8,6 +8,7 @@
         "Uuid",
         "Text",
         "Jsonb",
+        "Interval",
         "Interval",
         "Interval",
         "Interval",
@@ -42,5 +43,5 @@
     },
     "nullable": []
   },
-  "hash": "f4e7046f78c47d14c0243bc2b67e6b686b6eb97eff9738249b60a5eb9902b751"
+  "hash": "dae0ef841b214a8f0d3981f27aa490d09dd5db2962112316ae892a59fc7f152c"
 }

--- a/.sqlx/query-dbcd4dd5bde04b26279a795888276f9369c1322b5ead7cf2f31a3a869afa8e02.json
+++ b/.sqlx/query-dbcd4dd5bde04b26279a795888276f9369c1322b5ead7cf2f31a3a869afa8e02.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select last_heartbeat_at as \"last_heartbeat_at: i64\"\n            from underway.task\n            where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "last_heartbeat_at: i64",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "dbcd4dd5bde04b26279a795888276f9369c1322b5ead7cf2f31a3a869afa8e02"
+}

--- a/.sqlx/query-f4f48864425ba5853f5abf0e6afdf50e6df72667334faad74f9b70302283af92.json
+++ b/.sqlx/query-f4f48864425ba5853f5abf0e6afdf50e6df72667334faad74f9b70302283af92.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select heartbeat \n            from underway.task\n            where id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "heartbeat",
+        "type_info": "Interval"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "f4f48864425ba5853f5abf0e6afdf50e6df72667334faad74f9b70302283af92"
+}


### PR DESCRIPTION
This fixes an issue where enqueuing a task would not persist its heartbeat--it was simply not included in the query.

We address that here by including the heartbeat.

At the same time additional tests are provided to ensure coverage for task properties.