### PR TITLE
ensure job cancellation selection holds a lock

### DIFF
--- a/.sqlx/query-7513f95eb46920c91e32cf7dac34155bbaac4ee4a5011c110df702eab4c8e03f.json
+++ b/.sqlx/query-7513f95eb46920c91e32cf7dac34155bbaac4ee4a5011c110df702eab4c8e03f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select\n              id as \"id: TaskId\",\n              task_queue_name as \"queue_name\",\n              input,\n              retry_policy as \"retry_policy: RetryPolicy\",\n              timeout,\n              heartbeat,\n              concurrency_key\n            from underway.task\n            where input->>'job_id' = $1\n              and state = $2\n            ",
+  "query": "\n            select\n              id as \"id: TaskId\",\n              task_queue_name as \"queue_name\",\n              input,\n              retry_policy as \"retry_policy: RetryPolicy\",\n              timeout,\n              heartbeat,\n              concurrency_key\n            from underway.task\n            where input->>'job_id' = $1\n              and state = $2\n            for update skip locked\n            ",
   "describe": {
     "columns": [
       {
@@ -92,5 +92,5 @@
       true
     ]
   },
-  "hash": "24e7b0c00cda5634d04fe27cb833f12803108d0b4235d39fe372acd4b364d99d"
+  "hash": "7513f95eb46920c91e32cf7dac34155bbaac4ee4a5011c110df702eab4c8e03f"
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -906,6 +906,7 @@ impl<T: Task> EnqueuedJob<T> {
             from underway.task
             where input->>'job_id' = $1
               and state = $2
+            for update skip locked
             "#,
             self.id.to_string(),
             TaskState::Pending as TaskState


### PR DESCRIPTION
Since we select and then update a set of tasks in a transaction in order to cancel pending tasks relative to a given job, we should also hold a lock over that selection via `for update`.