### PR TITLE
reorder task and task_attempt primary key

### DIFF
--- a/migrations/20241126224448_5.sql
+++ b/migrations/20241126224448_5.sql
@@ -1,0 +1,15 @@
+-- Force anything running this migration to use the right search path.
+set local search_path to underway;
+
+alter table underway.task_attempt drop constraint task_attempt_task_id_task_queue_name_fkey;
+
+alter table underway.task drop constraint task_pkey;
+alter table underway.task add constraint task_pkey
+primary key (task_queue_name, id);
+
+alter table underway.task_attempt drop constraint task_attempt_pkey;
+alter table underway.task_attempt add constraint task_attempt_pkey
+primary key (task_queue_name, task_id, attempt_number);
+
+alter table underway.task_attempt add constraint task_attempt_task_queue_name_task_id_fkey
+foreign key (task_queue_name, task_id) references underway.task(task_queue_name, id) on delete cascade;


### PR DESCRIPTION
This reorders the task and task_attempt primary keys such that the queue name prefixes the index name. Because queues are contained within the same physical table, this prefix helps ensure better performance when selecting tasks from the queue.

Closes #68