### PR TITLE
ensure shutdown channels are unique

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 use crate::{
-    queue::{try_acquire_advisory_lock, Error as QueueError, SHUTDOWN_CHANNEL},
+    queue::{shutdown_channel, try_acquire_advisory_lock, Error as QueueError},
     Queue, Task,
 };
 
@@ -270,7 +270,8 @@ impl<T: Task> Scheduler<T> {
 
         // Set up a listener for shutdown notifications
         let mut shutdown_listener = PgListener::connect_with(&self.queue.pool).await?;
-        shutdown_listener.listen(SHUTDOWN_CHANNEL).await?;
+        let chan = shutdown_channel();
+        shutdown_listener.listen(chan).await?;
 
         // TODO: Handle updates to schedules?
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -137,7 +137,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 use crate::{
-    queue::{Error as QueueError, InProgressTask, Queue, SHUTDOWN_CHANNEL},
+    queue::{shutdown_channel, Error as QueueError, InProgressTask, Queue},
     task::{Error as TaskError, RetryCount, RetryPolicy, Task, TaskId},
 };
 pub(crate) type Result<T = ()> = std::result::Result<T, Error>;
@@ -507,7 +507,8 @@ impl<T: Task + Sync> Worker<T> {
 
         // Set up a listener for shutdown notifications
         let mut shutdown_listener = PgListener::connect_with(&self.queue.pool).await?;
-        shutdown_listener.listen(SHUTDOWN_CHANNEL).await?;
+        let chan = shutdown_channel();
+        shutdown_listener.listen(chan).await?;
 
         // Set up a listener for task change notifications
         let mut task_change_listener = PgListener::connect_with(&self.queue.pool).await?;


### PR DESCRIPTION
This changes how the shutdown channel is named such that channels are unique. Specifically the shutdown channel is not prepended with a UUID v4. Doing so ensures that multiple copies of e.g. workers and schedulers may be cooperatively run without interfering with one another's life cycle.