### PR TITLE
Introduce lease tokens for task fencing

### DIFF
--- a/migrations/20250212120000_4.sql
+++ b/migrations/20250212120000_4.sql
@@ -1,0 +1,11 @@
+-- Force anything running this migration to use the right search path.
+set local search_path to underway;
+
+alter table underway.task
+add column if not exists lease_token uuid;
+
+alter table underway.task
+add column if not exists lease_expires_at timestamp with time zone;
+
+alter table underway.task_attempt
+add column if not exists lease_token uuid;

--- a/src/job.rs
+++ b/src/job.rs
@@ -652,9 +652,7 @@ use uuid::Uuid;
 use crate::{
     queue::{Error as QueueError, InProgressTask, Queue},
     scheduler::{Error as SchedulerError, Scheduler, ZonedSchedule},
-    task::{
-        Error as TaskError, Result as TaskResult, RetryPolicy, State as TaskState, Task, TaskId,
-    },
+    task::{Error as TaskError, Result as TaskResult, RetryPolicy, State as TaskState, Task},
     worker::{Error as WorkerError, Worker},
 };
 
@@ -907,25 +905,26 @@ impl<T: Task> EnqueuedJob<T> {
     /// ```
     pub async fn cancel(&self) -> Result<bool> {
         let mut tx = self.queue.pool.begin().await?;
-        let in_progress_tasks = sqlx::query_as!(
-            InProgressTask,
+        let in_progress_tasks = sqlx::query_as::<_, InProgressTask>(
             r#"
             select
-              id as "id: TaskId",
-              task_queue_name as "queue_name",
+              id as id,
+              task_queue_name as queue_name,
               input,
-              retry_policy as "retry_policy: RetryPolicy",
+              retry_policy as retry_policy,
               timeout,
               heartbeat,
-              concurrency_key
+              concurrency_key,
+              0::int as attempt_number,
+              lease_token
             from underway.task
             where input->>'job_id' = $1
               and state = $2
             for update skip locked
             "#,
-            self.id.to_string(),
-            TaskState::Pending as TaskState
         )
+        .bind(self.id.to_string())
+        .bind(TaskState::Pending as TaskState)
         .fetch_all(&mut *tx)
         .await?;
 


### PR DESCRIPTION
### Motivation

- Prevent races where a stale attempt finalizes or reschedules a task after a new attempt has been created by introducing explicit per-attempt fencing.  
- Avoid brittle guards that relied on the task row `state` or the latest `attempt_number` alone.  
- Make staleness detection explicit by using an expiration timestamp rather than only heartbeat timestamps.  

### Description

- Add a migration that adds `lease_token` and `lease_expires_at` to `underway.task` and `lease_token` to `underway.task_attempt`.  
- Generate a new UUID lease on dequeue and store it on both the `task` row and the inserted `task_attempt`, and set `lease_expires_at = now() + heartbeat`.  
- Wire `lease_token` into `InProgressTask` and fence all attempt / task updates (`mark_succeeded`, `mark_failed`, `mark_cancelled`, `retry_after`, `record_failure`, and `record_heartbeat`) to require a matching lease and clear leases on terminal or reschedule transitions.  
- Replace staleness checks to use `lease_expires_at` and add a test that verifies a stale attempt cannot finalize a task (`stale_attempt_cannot_finalize_task`).  

### Testing

- Ran `cargo fmt`, which completed successfully.  
- No unit or integration tests were executed as part of this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c27dfc1c08333acba147aa7548cfc)