### PR TITLE
reap worker processing tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fix: Pending retry delays now respect the last attempt time when re-queuing tasks
+- Fix: Reap completed worker processing tasks to avoid unbounded memory growth
 
 # 0.2.0
 


### PR DESCRIPTION
## Summary
- reap completed worker processing tasks to keep JoinSet growth bounded
- add a regression test for JoinSet reaping
- document the fix in the changelog

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/underway cargo test` (fails: worker::tests::process_retries)