### PR TITLE
split workflow internals and activity registration typing

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -61,39 +61,6 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::task::RetryPolicy;
 
-/// Type-level activity registration set utilities.
-#[doc(hidden)]
-pub mod registration {
-    use std::marker::PhantomData;
-
-    use super::Activity;
-
-    /// Empty set of registered activities.
-    pub struct Nil;
-
-    /// Type-level set node.
-    pub struct Cons<Head, Tail>(pub(crate) PhantomData<(Head, Tail)>);
-
-    /// Type-level index for the head of a set.
-    pub struct Here;
-
-    /// Type-level index for an element in the tail of a set.
-    pub struct There<T>(pub(crate) PhantomData<T>);
-
-    /// Marker trait indicating `A` is present in an activity set.
-    pub trait Contains<A: Activity, Idx> {}
-
-    impl<A, Tail> Contains<A, Here> for Cons<A, Tail> where A: Activity {}
-
-    impl<A, Head, Tail, Idx> Contains<A, There<Idx>> for Cons<Head, Tail>
-    where
-        A: Activity,
-        Head: Activity,
-        Tail: Contains<A, Idx>,
-    {
-    }
-}
-
 /// A type alias for activity execution results.
 pub type Result<T> = StdResult<T, Error>;
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -125,21 +125,19 @@ impl RuntimeHandle {
 }
 
 /// High-level workflow runtime.
-pub struct Runtime<I, S, A = crate::activity::registration::Nil>
+pub struct Runtime<I, S>
 where
     I: Serialize + Send + Sync + 'static,
     S: Clone + Send + Sync + 'static,
-    A: 'static,
 {
-    workflow: Workflow<I, S, A>,
+    workflow: Workflow<I, S>,
     activity_worker: ActivityWorker,
 }
 
-impl<I, S, A> Clone for Runtime<I, S, A>
+impl<I, S> Clone for Runtime<I, S>
 where
     I: Serialize + Send + Sync + 'static,
     S: Clone + Send + Sync + 'static,
-    A: 'static,
 {
     fn clone(&self) -> Self {
         Self {
@@ -149,16 +147,15 @@ where
     }
 }
 
-impl<I, S, A> Runtime<I, S, A>
+impl<I, S> Runtime<I, S>
 where
     I: Serialize + Send + Sync + 'static,
     S: Clone + Send + Sync + 'static,
-    A: 'static,
 {
     /// Creates a runtime from a workflow.
     ///
     /// Registered activity handlers are sourced from the workflow's builder.
-    pub fn new(workflow: Workflow<I, S, A>) -> Self {
+    pub fn new(workflow: Workflow<I, S>) -> Self {
         let activity_worker = ActivityWorker::with_registry(
             workflow.queue().pool.clone(),
             workflow.queue().name.clone(),
@@ -171,7 +168,7 @@ where
     }
 
     /// Returns a reference to the workflow managed by this runtime.
-    pub fn workflow(&self) -> &Workflow<I, S, A> {
+    pub fn workflow(&self) -> &Workflow<I, S> {
         &self.workflow
     }
 
@@ -179,7 +176,7 @@ where
     ///
     /// This is useful when running worker loops manually instead of calling
     /// [`Runtime::run`] or [`Runtime::start`].
-    pub fn worker(&self) -> Worker<Workflow<I, S, A>> {
+    pub fn worker(&self) -> Worker<Workflow<I, S>> {
         Worker::new(self.workflow.queue(), self.workflow.clone())
     }
 
@@ -187,7 +184,7 @@ where
     ///
     /// This is useful when running scheduler loops manually instead of calling
     /// [`Runtime::run`] or [`Runtime::start`].
-    pub fn scheduler(&self) -> Scheduler<Workflow<I, S, A>> {
+    pub fn scheduler(&self) -> Scheduler<Workflow<I, S>> {
         Scheduler::new(self.workflow.queue(), self.workflow.clone())
     }
 
@@ -263,13 +260,12 @@ where
     }
 }
 
-impl<I, S, A> From<Workflow<I, S, A>> for Runtime<I, S, A>
+impl<I, S> From<Workflow<I, S>> for Runtime<I, S>
 where
     I: Serialize + Send + Sync + 'static,
     S: Clone + Send + Sync + 'static,
-    A: 'static,
 {
-    fn from(workflow: Workflow<I, S, A>) -> Self {
+    fn from(workflow: Workflow<I, S>) -> Self {
         Self::new(workflow)
     }
 }

--- a/src/workflow/registration.rs
+++ b/src/workflow/registration.rs
@@ -1,0 +1,59 @@
+use std::marker::PhantomData;
+
+use crate::activity::Activity;
+
+/// Marker type representing no registered activities.
+pub struct NoActivities;
+
+/// Type-level set node for registered activities.
+pub struct Registered<Head, Tail>(pub(crate) PhantomData<(Head, Tail)>);
+
+/// Type-level index for the head of a set.
+pub struct Here;
+
+/// Type-level index for an element in the tail of a set.
+pub struct There<T>(pub(crate) PhantomData<T>);
+
+mod sealed {
+    pub trait ActivitySet {}
+}
+
+/// Type-level set of activities registered on a workflow builder.
+pub trait ActivitySet: sealed::ActivitySet + 'static {}
+
+impl<T> ActivitySet for T where T: sealed::ActivitySet + 'static {}
+
+impl sealed::ActivitySet for NoActivities {}
+
+impl<Head, Tail> sealed::ActivitySet for Registered<Head, Tail>
+where
+    Head: Activity,
+    Tail: ActivitySet,
+{
+}
+
+mod private {
+    use super::{Activity, Here, Registered, There};
+
+    pub trait Contains<A: Activity, Idx> {}
+
+    impl<A, Tail> Contains<A, Here> for Registered<A, Tail> where A: Activity {}
+
+    impl<A, Head, Tail, Idx> Contains<A, There<Idx>> for Registered<Head, Tail>
+    where
+        A: Activity,
+        Head: Activity,
+        Tail: Contains<A, Idx>,
+    {
+    }
+}
+
+/// Marker trait indicating `A` is present in an activity set.
+pub trait Contains<A: Activity, Idx>: ActivitySet {}
+
+impl<Set, A, Idx> Contains<A, Idx> for Set
+where
+    Set: ActivitySet + private::Contains<A, Idx>,
+    A: Activity,
+{
+}

--- a/src/workflow/step.rs
+++ b/src/workflow/step.rs
@@ -1,0 +1,182 @@
+use std::{future::Future, marker::PhantomData, pin::Pin, sync::Arc};
+
+use jiff::{Span, ToSpan};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use super::{context::ContextParts, Context};
+use crate::task::{Error as TaskError, Result as TaskResult, RetryPolicy};
+
+pub(super) struct StepConfig<S> {
+    pub(super) executor: Box<dyn StepExecutor<S>>,
+    pub(super) task_config: StepTaskConfig,
+}
+
+impl<S> StepConfig<S> {
+    pub(super) fn new<I, O, A, F, Fut>(func: F) -> Self
+    where
+        I: DeserializeOwned + Serialize + Send + Sync + 'static,
+        O: Serialize + Send + Sync + 'static,
+        S: Send + Sync + 'static,
+        A: 'static,
+        F: Fn(Context<S, A>, I) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = TaskResult<To<O>>> + Send + 'static,
+    {
+        let step_fn = StepFn::new(move |cx, input| Box::pin(func(cx, input)));
+        Self {
+            executor: Box::new(step_fn),
+            task_config: StepTaskConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct StepTaskConfig {
+    pub(super) retry_policy: RetryPolicy,
+    pub(super) timeout: Span,
+    pub(super) ttl: Span,
+    pub(super) delay: Span,
+    pub(super) heartbeat: Span,
+    pub(super) concurrency_key: Option<String>,
+    pub(super) priority: i32,
+}
+
+impl Default for StepTaskConfig {
+    fn default() -> Self {
+        Self {
+            retry_policy: RetryPolicy::default(),
+            timeout: 15.minutes(),
+            ttl: 14.days(),
+            delay: Span::new(),
+            heartbeat: 30.seconds(),
+            concurrency_key: None,
+            priority: 0,
+        }
+    }
+}
+
+/// Represents the state after executing a step.
+#[derive(Deserialize, Serialize)]
+pub enum To<N> {
+    /// The next step to transition to.
+    Next(N),
+
+    /// The next step to transition to after the delay.
+    Delay {
+        /// The step itself.
+        next: N,
+
+        /// The delay before which the step will not be run.
+        delay: Span,
+    },
+
+    /// The terminal state.
+    Done,
+}
+
+impl<S> To<S> {
+    /// Transitions from the current step to the next step.
+    pub fn next(step: S) -> TaskResult<Self> {
+        Ok(Self::Next(step))
+    }
+
+    /// Transitions from the current step to the next step, but after the given
+    /// delay.
+    ///
+    /// The next step will be enqueued immediately, but won't be dequeued until
+    /// the span has elapsed.
+    pub fn delay_for(step: S, delay: Span) -> TaskResult<Self> {
+        Ok(Self::Delay { next: step, delay })
+    }
+}
+
+impl To<()> {
+    /// Signals that this is the final step and no more steps will follow.
+    pub fn done() -> TaskResult<To<()>> {
+        Ok(To::Done)
+    }
+}
+
+type StepFnMarker<I, O, S, A> = fn() -> (I, O, S, A);
+
+struct StepFn<I, O, S, A, F>
+where
+    F: Fn(Context<S, A>, I) -> Pin<Box<dyn Future<Output = TaskResult<To<O>>> + Send>>
+        + Send
+        + Sync
+        + 'static,
+{
+    func: Arc<F>,
+    _marker: PhantomData<StepFnMarker<I, O, S, A>>,
+}
+
+impl<I, O, S, A, F> StepFn<I, O, S, A, F>
+where
+    F: Fn(Context<S, A>, I) -> Pin<Box<dyn Future<Output = TaskResult<To<O>>> + Send>>
+        + Send
+        + Sync
+        + 'static,
+{
+    fn new(func: F) -> Self {
+        Self {
+            func: Arc::new(func),
+            _marker: PhantomData,
+        }
+    }
+}
+
+type StepResult = TaskResult<Option<(serde_json::Value, Span)>>;
+
+pub(super) trait StepExecutor<S>: Send + Sync {
+    fn execute_step(
+        &self,
+        cx: ContextParts<S>,
+        input: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = StepResult> + Send>>;
+}
+
+impl<I, O, S, A, F> StepExecutor<S> for StepFn<I, O, S, A, F>
+where
+    I: DeserializeOwned + Serialize + Send + Sync + 'static,
+    O: Serialize + Send + Sync + 'static,
+    S: Send + Sync + 'static,
+    F: Fn(Context<S, A>, I) -> Pin<Box<dyn Future<Output = TaskResult<To<O>>> + Send>>
+        + Send
+        + Sync
+        + 'static,
+{
+    fn execute_step(
+        &self,
+        cx: ContextParts<S>,
+        input: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = StepResult> + Send>> {
+        let deserialized_input: I = match serde_json::from_value(input) {
+            Ok(val) => val,
+            Err(err) => return Box::pin(async move { Err(TaskError::Fatal(err.to_string())) }),
+        };
+        let cx: Context<S, A> = Context::from_parts(cx);
+        let fut = (self.func)(cx, deserialized_input);
+
+        Box::pin(async move {
+            match fut.await {
+                Ok(To::Next(output)) => {
+                    let serialized_output = serde_json::to_value(output)
+                        .map_err(|err| TaskError::Fatal(err.to_string()))?;
+                    Ok(Some((serialized_output, Span::new())))
+                }
+
+                Ok(To::Delay {
+                    next: output,
+                    delay,
+                }) => {
+                    let serialized_output = serde_json::to_value(output)
+                        .map_err(|err| TaskError::Fatal(err.to_string()))?;
+                    Ok(Some((serialized_output, delay)))
+                }
+
+                Ok(To::Done) => Ok(None),
+
+                Err(err) => Err(err),
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- keep `src/workflow.rs` as the module root while moving builder/context internals into dedicated submodules and introducing `workflow::step` for step execution plumbing
- move activity registration type-level machinery out of `activity` and into `workflow::registration`, keeping compile-time `Context::call`/`emit` checks while reducing leaked internals
- remove the activity-set generic from public `Workflow`/`Runtime` types by erasing it behind step executors and `ContextParts`

## Validation
- `cargo +nightly fmt --all`
- `SQLX_OFFLINE=true cargo check --all-features`
- `SQLX_OFFLINE=true cargo clippy --all --all-targets --all-features -- -Dwarnings`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/underway_sqlx cargo test --workspace --all-features --lib`
- `RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" SQLX_OFFLINE=true cargo doc --all-features --no-deps`