### PR TITLE
regenerate workflow ids from scheduled templates

### DIFF
--- a/.sqlx/query-ee3d278c6722b44e8f6ccca0aa76430a98ead708dba55daf8d3b9523434e4273.json
+++ b/.sqlx/query-ee3d278c6722b44e8f6ccca0aa76430a98ead708dba55daf8d3b9523434e4273.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select input\n            from underway.task_schedule\n            where task_queue_name = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "input",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ee3d278c6722b44e8f6ccca0aa76430a98ead708dba55daf8d3b9523434e4273"
+}

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1162,6 +1162,24 @@ impl<T: Task> Queue<T> {
     {
         let input_value = serde_json::to_value(input)?;
 
+        self.schedule_value(executor, zoned_schedule, input_value)
+            .await
+    }
+
+    #[instrument(
+        skip(self, executor, zoned_schedule, input_value),
+        fields(queue.name = self.name),
+        err
+    )]
+    pub(crate) async fn schedule_value<'a, E>(
+        &self,
+        executor: E,
+        zoned_schedule: &ZonedSchedule,
+        input_value: serde_json::Value,
+    ) -> Result
+    where
+        E: PgExecutor<'a>,
+    {
         sqlx::query!(
             r#"
             insert into underway.task_schedule (

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -419,8 +419,6 @@ impl<T: Task> Scheduler<T> {
             return Ok(());
         };
 
-        let input = self.task.scheduled_input(input);
-
         let task_id = self
             .queue
             .enqueue(&self.queue.pool, &self.task, &input)

--- a/src/task.rs
+++ b/src/task.rs
@@ -615,16 +615,6 @@ pub trait Task: Send + 'static {
     fn priority_for(&self, _input: &Self::Input) -> i32 {
         self.priority()
     }
-
-    /// Returns the input that should be enqueued for a scheduled dispatch.
-    ///
-    /// By default this returns the provided input unchanged.
-    ///
-    /// Tasks may override this to adjust per-dispatch fields when running from
-    /// a schedule. For example, workflows can regenerate per-run identifiers.
-    fn scheduled_input(&self, input: Self::Input) -> Self::Input {
-        input
-    }
 }
 
 /// Represents the possible states a task can be in.


### PR DESCRIPTION
## Summary
- store scheduled workflow input as a template (`step_index` + `step_input`) without persisting `workflow_id`
- add internal `Queue::schedule_value` so workflow scheduling can persist template JSON directly while keeping `Queue::schedule` typed
- deserialize workflow schedule input with `workflow_id` default generation, so each scheduler dispatch materializes a fresh id
- keep scheduler dispatch-time schedule reads and add regression assertions that scheduled reads yield distinct workflow ids and stored template JSON omits `workflow_id`

## Testing
- cargo test --lib
- SQLX_OFFLINE=true cargo check --all-targets
- SQLX_OFFLINE=true cargo clippy --all --all-targets --all-features -- -Dwarnings

Fixes #126
Refs #137