### PR TITLE
derive activity call keys from execution order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Breaking: Remove `workflow::Context::tx`; step contexts no longer expose a worker transaction directly
 - Breaking: Workflow activities are now registered on `Workflow::builder()` before steps
+- Breaking: Remove manual keys from `workflow::Context::call` and `workflow::Context::emit`; activity operation identity is now derived from workflow run ID, step index, and per-step operation order
 - Add: `Runtime` high-level orchestration API sourced from builder-registered activities
 - Breaking: Remove `Workflow::run` and `Workflow::start`; use `workflow.runtime().run()` / `workflow.runtime().start()`
 - Breaking: Remove `Workflow::worker` and `Workflow::scheduler`; use `workflow.runtime().worker()` / `workflow.runtime().scheduler()`

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .activity(LookupEmail { pool: pool.clone() })
         .activity(TrackSignupMetric)
         .step(|mut cx, Signup { user_id }| async move {
-            let email: String = cx.call::<LookupEmail, _>("lookup", &user_id).await?;
-            cx.emit::<TrackSignupMetric, _>("track", &email).await?;
+            let email: String = cx.call::<LookupEmail, _>(&user_id).await?;
+            cx.emit::<TrackSignupMetric, _>(&email).await?;
             To::done()
         })
         .name("signup-side-effects")

--- a/examples/activities/src/main.rs
+++ b/examples/activities/src/main.rs
@@ -71,8 +71,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let resolved_emails = cx.state.resolved_emails.clone();
 
             async move {
-                let email: String = cx.call::<LookupEmail, _>("lookup", &user_id).await?;
-                cx.emit::<TrackSignupMetric, _>("track-signup", &email).await?;
+                let email: String = cx.call::<LookupEmail, _>(&user_id).await?;
+                cx.emit::<TrackSignupMetric, _>(&email).await?;
                 resolved_emails.lock().await.push(email);
                 To::done()
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@
 //! let workflow = Workflow::builder()
 //!     .activity(ResolveEmail)
 //!     .step(|mut cx, Input { user_id }| async move {
-//!         let _email: String = cx.call::<ResolveEmail, _>("resolve", &user_id).await?;
+//!         let _email: String = cx.call::<ResolveEmail, _>(&user_id).await?;
 //!         To::done()
 //!     })
 //!     .name("resolve-email")
@@ -247,8 +247,8 @@
 //!     .activity(LookupEmail { pool: pool.clone() })
 //!     .activity(TrackSignupMetric)
 //!     .step(|mut cx, Signup { user_id }| async move {
-//!         let email: String = cx.call::<LookupEmail, _>("lookup", &user_id).await?;
-//!         cx.emit::<TrackSignupMetric, _>("track", &email).await?;
+//!         let email: String = cx.call::<LookupEmail, _>(&user_id).await?;
+//!         cx.emit::<TrackSignupMetric, _>(&email).await?;
 //!         To::done()
 //!     })
 //!     .name("signup-side-effects")


### PR DESCRIPTION
## Summary
- remove manual key parameters from `Context::call` and `Context::emit` and derive activity operation keys from workflow run id, step index, and deterministic per-step operation order
- require `&mut self` for `emit` to preserve deterministic sequencing alongside `call`, while retaining nondeterminism checks against persisted activity records
- update docs, examples, runtime/workflow tests, and the changelog to reflect the breaking API and behavior