### PR TITLE
switch activity calls to invokeactivity helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 - Breaking: Remove `workflow::Context::tx`; step contexts no longer expose a worker transaction directly
 - Breaking: Workflow activities are now registered on `Workflow::builder()` before steps
-- Breaking: Remove manual keys from `workflow::Context::call` and `workflow::Context::emit`; activity operation identity is now derived from workflow run ID, step index, and per-step operation order
+- Breaking: Remove manual activity keys; operation identity is now derived from workflow run ID, step index, and per-step operation order
 - Add: `Runtime` high-level orchestration API sourced from builder-registered activities
 - Breaking: Remove `Workflow::run` and `Workflow::start`; use `workflow.runtime().run()` / `workflow.runtime().start()`
 - Breaking: Remove `Workflow::worker` and `Workflow::scheduler`; use `workflow.runtime().worker()` / `workflow.runtime().scheduler()`
 - Add: `Activity` trait and standard activity error envelope
-- Add: Durable typed `Context::call::<A, _>` and `Context::emit::<A, _>` primitives with compile-time registration checks
+- Add: Durable typed `workflow::InvokeActivity` helpers (`A::call` / `A::emit`) with compile-time registration checks
 - Add: `waiting` task state to support workflow suspension while activity calls complete
 - Breaking: Rename `enqueue_multi` to `enqueue_many` and return task IDs for batch enqueue
 - Perf: Optimize `enqueue_many` for uniform-config batches

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -4,9 +4,9 @@
 //! Unlike workflow code, activity handlers are expected to perform external
 //! I/O such as HTTP requests, emails, or writes to other systems.
 //!
-//! Workflow steps call activities via [`crate::workflow::Context::call`] and
-//! [`crate::workflow::Context::emit`]. Calls are persisted and executed by the
-//! activity worker managed by [`crate::Runtime`].
+//! Workflow steps call activities via [`crate::workflow::InvokeActivity`].
+//! Calls are persisted and executed by the activity worker managed by
+//! [`crate::Runtime`].
 //!
 //! # Defining activities
 //!

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -17,7 +17,7 @@
 //! ```rust,no_run
 //! use serde::{Deserialize, Serialize};
 //! use sqlx::PgPool;
-//! use underway::{Activity, ActivityError, Transition, Workflow};
+//! use underway::{Activity, ActivityError, InvokeActivity, Transition, Workflow};
 //!
 //! #[derive(Deserialize, Serialize)]
 //! struct FetchUser {
@@ -50,7 +50,7 @@
 //!     let workflow = Workflow::builder()
 //!         .activity(LookupEmail)
 //!         .step(|mut cx, FetchUser { user_id }| async move {
-//!             let email: String = cx.call::<LookupEmail, _>(&user_id).await?;
+//!             let email: String = LookupEmail::call(&mut cx, &user_id).await?;
 //!             println!("Got email {email}");
 //!             Transition::complete()
 //!         })
@@ -284,6 +284,7 @@ mod tests {
     use super::Runtime;
     use crate::{
         activity::{Activity, CallState, Result as ActivityResult},
+        workflow::InvokeActivity,
         Transition, Workflow,
     };
 
@@ -338,7 +339,7 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EchoActivity)
             .step(|mut cx, Step1 { message }| async move {
-                let echoed: String = cx.call::<EchoActivity, _>(&message).await?;
+                let echoed: String = EchoActivity::call(&mut cx, &message).await?;
                 Transition::next(Step2 { echoed })
             })
             .step(move |_cx, Step2 { echoed }| {
@@ -425,7 +426,7 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EchoActivity)
             .step(|mut cx, MessageInput { message }| async move {
-                let _: String = cx.call::<EchoActivity, _>(&message).await?;
+                let _: String = EchoActivity::call(&mut cx, &message).await?;
                 Transition::complete()
             })
             .name(queue_name)
@@ -511,7 +512,7 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EchoActivity)
             .step(|mut cx, Step1 { message }| async move {
-                let echoed: String = cx.call::<EchoActivity, _>(&message).await?;
+                let echoed: String = EchoActivity::call(&mut cx, &message).await?;
                 Transition::next(Step2 { echoed })
             })
             .step(move |_cx, Step2 { echoed }| {

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -41,9 +41,9 @@
 //! Notice that the first argument to our function is [a context
 //! binding](crate::workflow::Context). This provides access to fields like
 //! [`state`](crate::workflow::Context::state) and
-//! [`workflow_run_id`](crate::workflow::Context::workflow_run_id), as well as
-//! workflow helpers like [`call`](crate::workflow::Context::call) and
-//! [`emit`](crate::workflow::Context::emit).
+//! [`workflow_run_id`](crate::workflow::Context::workflow_run_id).
+//! Durable activity invocation helpers are provided on activity contracts via
+//! [`workflow::InvokeActivity`](crate::workflow::InvokeActivity).
 //! Activity calls are type-checked against handlers registered on
 //! [`workflow::Builder::activity`](crate::workflow::Builder::activity).
 //!
@@ -259,9 +259,11 @@
 //! Workflow steps do not expose a raw database transaction directly.
 //! Use durable activity helpers for side effects instead.
 //!
-//! Instead, durable side effects are modeled with workflow helpers:
-//! - [`Context::emit`] for fire-and-forget intents, and
-//! - [`Context::call`] for request/response effects.
+//! Instead, durable side effects are modeled with activity invocation helpers:
+//! - [`workflow::InvokeActivity::emit`](crate::workflow::InvokeActivity::emit)
+//!   for fire-and-forget intents, and
+//! - [`workflow::InvokeActivity::call`](crate::workflow::InvokeActivity::call)
+//!   for request/response effects.
 //!
 //! Activities must be registered on the workflow builder before any step that
 //! calls or emits them. Missing registrations fail at compile time.
@@ -273,7 +275,7 @@
 //!
 //! ```rust
 //! use serde::{Deserialize, Serialize};
-//! use underway::{Activity, Transition, Workflow};
+//! use underway::{Activity, InvokeActivity, Transition, Workflow};
 //!
 //! #[derive(Serialize, Deserialize)]
 //! struct Step1 {
@@ -316,10 +318,10 @@
 //!     .activity(WriteAuditLog)
 //!     .step(|mut cx, Step1 { user_id }| async move {
 //!         // Fire-and-forget effect intent.
-//!         cx.emit::<WriteAuditLog, _>(&user_id).await?;
+//!         WriteAuditLog::emit(&mut cx, &user_id).await?;
 //!
 //!         // Suspends/resumes durably until completion.
-//!         let profile_id: i64 = cx.call::<CreateProfile, _>(&user_id).await?;
+//!         let profile_id: i64 = CreateProfile::call(&mut cx, &user_id).await?;
 //!         Transition::next(Step2 { profile_id })
 //!     })
 //!     .step(|_cx, Step2 { profile_id: _ }| async move { Transition::complete() });
@@ -329,10 +331,10 @@
 //! deterministic operation order within the step. Reordering operations in
 //! in-flight workflow runs is non-deterministic and fails execution.
 //!
-//! Because [`Context::call`] and [`Context::emit`] require mutable context,
+//! Because activity invocation helpers require mutable context,
 //! activity operations are issued sequentially within a step. Multiple
 //! unresolved calls in parallel are not supported; issue calls as
-//! `call(...).await?`.
+//! `MyActivity::call(&mut cx, ...).await?`.
 //!
 //! If a workflow needs direct transaction-level database semantics, implement
 //! [`Task`] directly and use its `execute` method, which receives
@@ -709,8 +711,8 @@ use std::{
 
 pub use builder::Builder;
 use builder::Initial;
-pub use context::Context;
 use context::{ActivityCallBuffer, ActivityCallRecord, CallSequenceState, ContextParts};
+pub use context::{Context, InvokeActivity};
 use jiff::Span;
 use sealed::{WorkflowScheduleTemplate, WorkflowState};
 use serde::{Deserialize, Serialize};
@@ -2588,7 +2590,7 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EchoActivity)
             .step(|mut cx, Input { message }| async move {
-                let _: String = cx.call::<EchoActivity, _>(&message).await?;
+                let _: String = EchoActivity::call(&mut cx, &message).await?;
                 Transition::complete()
             })
             .name("call_suspends_and_persists_activity_intent")
@@ -2651,7 +2653,7 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EmailActivity)
             .step(|mut cx, Input { message }| async move {
-                cx.emit::<EmailActivity, _>(&message).await?;
+                EmailActivity::emit(&mut cx, &message).await?;
                 Err(TaskError::Retryable("retry me".to_string()))
             })
             .name("emit_not_persisted_on_retryable_failure")
@@ -2695,7 +2697,7 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EmailActivity)
             .step(|mut cx, Input { message }| async move {
-                cx.emit::<EmailActivity, _>(&message).await?;
+                EmailActivity::emit(&mut cx, &message).await?;
                 Transition::complete()
             })
             .name("emit_persisted_on_success")
@@ -2739,10 +2741,10 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EchoActivity)
             .step(|mut cx, Input { message }| async move {
-                let first = cx.call::<EchoActivity, _>(&message).await;
+                let first = EchoActivity::call(&mut cx, &message).await;
                 assert!(matches!(first, Err(TaskError::Suspended(_))));
 
-                let _ = cx.call::<EchoActivity, _>(&message).await?;
+                let _ = EchoActivity::call(&mut cx, &message).await?;
 
                 Transition::complete()
             })


### PR DESCRIPTION
## Summary
- keep single-phase activity registration on `Workflow::builder().activity(...)` and remove the `declare + bind` runtime wiring experiment
- preserve deterministic derived activity keys while moving invocation ergonomics to `workflow::InvokeActivity` (`A::call` / `A::emit`) so call sites no longer require `Context::call::<A, _>` / `Context::emit::<A, _>`
- update workflow/runtime/library docs, examples, and tests to the new activity-centric invocation API