### PR TITLE
switch activity calls to invokeactivity helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 - Breaking: Remove `workflow::Context::tx`; step contexts no longer expose a worker transaction directly
 - Breaking: Workflow activities are now registered on `Workflow::builder()` before steps
-- Breaking: Remove manual keys from `workflow::Context::call` and `workflow::Context::emit`; activity operation identity is now derived from workflow run ID, step index, and per-step operation order
+- Breaking: Remove manual activity keys; operation identity is now derived from workflow run ID, step index, and per-step operation order
 - Add: `Runtime` high-level orchestration API sourced from builder-registered activities
 - Breaking: Remove `Workflow::run` and `Workflow::start`; use `workflow.runtime().run()` / `workflow.runtime().start()`
 - Breaking: Remove `Workflow::worker` and `Workflow::scheduler`; use `workflow.runtime().worker()` / `workflow.runtime().scheduler()`
 - Add: `Activity` trait and standard activity error envelope
-- Add: Durable typed `Context::call::<A, _>` and `Context::emit::<A, _>` primitives with compile-time registration checks
+- Add: Durable typed `workflow::InvokeActivity` helpers (`A::call` / `A::emit`) with compile-time registration checks
 - Add: `waiting` task state to support workflow suspension while activity calls complete
 - Breaking: Rename `enqueue_multi` to `enqueue_many` and return task IDs for batch enqueue
 - Perf: Optimize `enqueue_many` for uniform-config batches

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -4,9 +4,9 @@
 //! Unlike workflow code, activity handlers are expected to perform external
 //! I/O such as HTTP requests, emails, or writes to other systems.
 //!
-//! Workflow steps call activities via [`crate::workflow::Context::call`] and
-//! [`crate::workflow::Context::emit`]. Calls are persisted and executed by the
-//! activity worker managed by [`crate::Runtime`].
+//! Workflow steps call activities via [`crate::workflow::InvokeActivity`].
+//! Calls are persisted and executed by the activity worker managed by
+//! [`crate::Runtime`].
 //!
 //! # Defining activities
 //!

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -17,7 +17,7 @@
 //! ```rust,no_run
 //! use serde::{Deserialize, Serialize};
 //! use sqlx::PgPool;
-//! use underway::{Activity, ActivityError, Transition, Workflow};
+//! use underway::{Activity, ActivityError, InvokeActivity, Transition, Workflow};
 //!
 //! #[derive(Deserialize, Serialize)]
 //! struct FetchUser {
@@ -50,7 +50,7 @@
 //!     let workflow = Workflow::builder()
 //!         .activity(LookupEmail)
 //!         .step(|mut cx, FetchUser { user_id }| async move {
-//!             let email: String = cx.call::<LookupEmail, _>(&user_id).await?;
+//!             let email: String = LookupEmail::call(&mut cx, &user_id).await?;
 //!             println!("Got email {email}");
 //!             Transition::complete()
 //!         })
@@ -284,6 +284,7 @@ mod tests {
     use super::Runtime;
     use crate::{
         activity::{Activity, CallState, Result as ActivityResult},
+        workflow::InvokeActivity,
         Transition, Workflow,
     };
 
@@ -338,7 +339,7 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EchoActivity)
             .step(|mut cx, Step1 { message }| async move {
-                let echoed: String = cx.call::<EchoActivity, _>(&message).await?;
+                let echoed: String = EchoActivity::call(&mut cx, &message).await?;
                 Transition::next(Step2 { echoed })
             })
             .step(move |_cx, Step2 { echoed }| {
@@ -425,7 +426,7 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EchoActivity)
             .step(|mut cx, MessageInput { message }| async move {
-                let _: String = cx.call::<EchoActivity, _>(&message).await?;
+                let _: String = EchoActivity::call(&mut cx, &message).await?;
                 Transition::complete()
             })
             .name(queue_name)
@@ -511,7 +512,7 @@ mod tests {
         let workflow = Workflow::builder()
             .activity(EchoActivity)
             .step(|mut cx, Step1 { message }| async move {
-                let echoed: String = cx.call::<EchoActivity, _>(&message).await?;
+                let echoed: String = EchoActivity::call(&mut cx, &message).await?;
                 Transition::next(Step2 { echoed })
             })
             .step(move |_cx, Step2 { echoed }| {


### PR DESCRIPTION
## Summary
- keep single-phase activity registration on `Workflow::builder().activity(...)` and remove the `declare + bind` runtime wiring experiment
- preserve deterministic derived activity keys while moving invocation ergonomics to `workflow::InvokeActivity` (`A::call` / `A::emit`) so call sites no longer require `Context::call::<A, _>` / `Context::emit::<A, _>`
- update workflow/runtime/library docs, examples, and tests to the new activity-centric invocation API