### PR TITLE
make `ZonedScheduleError` publicly visible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ pub use crate::{
     activity::{Activity, CallState as ActivityCallState, Error as ActivityError},
     queue::Queue,
     runtime::Runtime,
-    scheduler::{Scheduler, ZonedSchedule},
+    scheduler::{Scheduler, ZonedSchedule, ZonedScheduleError},
     task::{Task, ToTaskResult},
     worker::Worker,
     workflow::{InvokeActivity, Transition, Workflow},


### PR DESCRIPTION
```rs
enum MyError {
  // this requires `ZonedScheduleError`
  CronParse(????)
}

let every_minute = "0 * * * * *[America/Los_Angeles]".parse().map_err(MyError::CronParse)?;
job.schedule(&every_minute, &()).await?;
```
Also, it is problematic at [`underway::ZonedSchedule::new`](https://docs.rs/underway/0.2.0/underway/struct.ZonedSchedule.html#method.new) too.